### PR TITLE
feat: added number transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,20 +132,20 @@ s.number.finite; // value must be finite
 s.number.positive; // .ge(0)
 s.number.negative; // .lt(0)
 
-s.number.divisibleBy(5); // TODO | Divisible by 5
+s.number.divisibleBy(5); // Divisible by 5
 ```
 
 And transformations:
 
 ```typescript
-s.number.abs; // TODO | Transforms the number to an absolute number
-s.number.sign; // TODO | Gets the number's sign
+s.number.abs; // Transforms the number to an absolute number
+s.number.sign; // Gets the number's sign
 
-s.number.trunc; // TODO | Transforms the number to the result of Math.trunc`
-s.number.floor; // TODO | Transforms the number to the result of Math.floor`
-s.number.fround; // TODO | Transforms the number to the result of Math.fround`
-s.number.round; // TODO | Transforms the number to the result of Math.round`
-s.number.ceil; // TODO | Transforms the number to the result of Math.ceil`
+s.number.trunc; // Transforms the number to the result of `Math.trunc`
+s.number.floor; // Transforms the number to the result of `Math.floor`
+s.number.fround; // Transforms the number to the result of `Math.fround`
+s.number.round; // Transforms the number to the result of `Math.round`
+s.number.ceil; // Transforms the number to the result of `Math.ceil`
 ```
 
 #### BigInts
@@ -419,7 +419,7 @@ All schemas in ShapeShift contain certain methods.
 ```typescript
 import { s } from '@sapphire/shapeshift';
 
-const getLength = s.string.transform((value) => value.length); // TODO
+const getLength = s.string.transform((value) => value.length);
 getLength.parse('Hello There'); // => 11
 ```
 

--- a/src/constraints/NumberConstraints.ts
+++ b/src/constraints/NumberConstraints.ts
@@ -98,3 +98,21 @@ export const numberNeNaN: IConstraint<number> = {
 			: Result.ok(input);
 	}
 };
+
+export function numberDivisibleBy(divider: number): IConstraint<number> {
+	const expected = `% ${divider}`;
+	return {
+		run(input: number) {
+			return input % divider === 0 //
+				? Result.ok(input)
+				: Result.err(
+						new ConstraintError(
+							'numberDivisibleBy',
+							`Expected number to be divisible by ${divider}, but received ${input}`,
+							input,
+							expected
+						)
+				  );
+		}
+	};
+}

--- a/src/validators/BaseValidator.ts
+++ b/src/validators/BaseValidator.ts
@@ -1,6 +1,6 @@
 import type { IConstraint } from '../constraints/base/IConstraint';
 import type { ValidationError } from '../lib/errors/ValidationError';
-import type { Result } from '../lib/Result';
+import { Result } from '../lib/Result';
 import { ArrayValidator, LiteralValidator, NullishValidator, SetValidator, UnionValidator } from './imports';
 
 export abstract class BaseValidator<T> {
@@ -32,6 +32,12 @@ export abstract class BaseValidator<T> {
 
 	public or<O>(...predicates: readonly BaseValidator<O>[]): UnionValidator<T | O> {
 		return new UnionValidator<T | O>([this.clone(), ...predicates]);
+	}
+
+	public transform(cb: (value: T) => T): this;
+	public transform<O>(cb: (value: T) => O): BaseValidator<O>;
+	public transform<O>(cb: (value: T) => O): BaseValidator<O> {
+		return this.addConstraint({ run: (input) => Result.ok(cb(input) as unknown as T) }) as unknown as BaseValidator<O>;
 	}
 
 	public run(value: unknown): Result<T, Error> {

--- a/src/validators/NumberValidator.ts
+++ b/src/validators/NumberValidator.ts
@@ -1,5 +1,6 @@
 import type { IConstraint } from '../constraints/base/IConstraint';
 import {
+	numberDivisibleBy,
 	numberEq,
 	numberFinite,
 	numberGe,
@@ -63,6 +64,38 @@ export class NumberValidator<T extends number> extends BaseValidator<T> {
 
 	public get negative(): this {
 		return this.lt(0);
+	}
+
+	public divisibleBy(divider: number): this {
+		return this.addConstraint(numberDivisibleBy(divider) as IConstraint<T>);
+	}
+
+	public get abs(): this {
+		return this.transform(Math.abs as (value: number) => T);
+	}
+
+	public get sign(): this {
+		return this.transform(Math.sign as (value: number) => T);
+	}
+
+	public get trunc(): this {
+		return this.transform(Math.trunc as (value: number) => T);
+	}
+
+	public get floor(): this {
+		return this.transform(Math.floor as (value: number) => T);
+	}
+
+	public get fround(): this {
+		return this.transform(Math.fround as (value: number) => T);
+	}
+
+	public get round(): this {
+		return this.transform(Math.round as (value: number) => T);
+	}
+
+	public get ceil(): this {
+		return this.transform(Math.ceil as (value: number) => T);
 	}
 
 	protected handle(value: unknown): Result<T, ValidationError> {

--- a/tests/validators/number.test.ts
+++ b/tests/validators/number.test.ts
@@ -1,5 +1,9 @@
 import { ConstraintError, s, ValidationError } from '../../src';
 
+const safeInteger = 42;
+// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+const unsafeInteger = 242043489611808769;
+
 describe('NumberValidator', () => {
 	const predicate = s.number;
 
@@ -59,10 +63,6 @@ describe('NumberValidator', () => {
 	});
 
 	describe('Constraints', () => {
-		const safeInteger = 42;
-		// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
-		const unsafeInteger = 242043489611808769;
-
 		describe('Integer', () => {
 			const intPredicate = s.number.int;
 
@@ -158,6 +158,78 @@ describe('NumberValidator', () => {
 				expect(() => neNanPredicate.parse(input)).toThrow(
 					new ConstraintError('numberNeNaN', `Expected number to not be a NaN, but received ${input}`, input, 'Not NaN')
 				);
+			});
+		});
+
+		describe('DivisibleBy', () => {
+			const divisibleByPredicate = s.number.divisibleBy(5);
+
+			test.each([5, 10, 20, 500])('GIVEN %d THEN returns given value', (input) => {
+				expect(divisibleByPredicate.parse(input)).toBe(input);
+			});
+
+			test.each([safeInteger, unsafeInteger, 6, 42.1, Infinity, -Infinity, NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
+				expect(() => divisibleByPredicate.parse(input)).toThrow(
+					new ConstraintError('numberDivisibleBy', `Expected number to be divisible by 5, but received ${input}`, input, '% 5')
+				);
+			});
+		});
+	});
+
+	describe('Transformers', () => {
+		describe('abs', () => {
+			const absPredicate = s.number.abs;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.abs', (input) => {
+				expect(absPredicate.parse(input)).toBe(Math.abs(input));
+			});
+		});
+
+		describe('sign', () => {
+			const signPredicate = s.number.sign;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.sign', (input) => {
+				expect(signPredicate.parse(input)).toBe(Math.sign(input));
+			});
+		});
+
+		describe('trunc', () => {
+			const truncPredicate = s.number.trunc;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.trunc', (input) => {
+				expect(truncPredicate.parse(input)).toBe(Math.trunc(input));
+			});
+		});
+
+		describe('floor', () => {
+			const floorPredicate = s.number.floor;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.floor', (input) => {
+				expect(floorPredicate.parse(input)).toBe(Math.floor(input));
+			});
+		});
+
+		describe('fround', () => {
+			const froundPredicate = s.number.fround;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.fround', (input) => {
+				expect(froundPredicate.parse(input)).toBe(Math.fround(input));
+			});
+		});
+
+		describe('round', () => {
+			const roundPredicate = s.number.round;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.round', (input) => {
+				expect(roundPredicate.parse(input)).toBe(Math.round(input));
+			});
+		});
+
+		describe('ceil', () => {
+			const ceilPredicate = s.number.ceil;
+
+			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN returns transformed the result from Math.ceil', (input) => {
+				expect(ceilPredicate.parse(input)).toBe(Math.ceil(input));
 			});
 		});
 	});


### PR DESCRIPTION
Adds the following methods:

- `BaseValidator#transform`
- `s.number.divisibleBy(n)`
- `s.number.abs`
- `s.number.sign`
- `s.number.trunc`
- `s.number.floor`
- `s.number.fround`
- `s.number.round`
- `s.number.ceil`
