### PR TITLE
refactor: add macros for tests

### DIFF
--- a/src/constraints/DateConstraints.ts
+++ b/src/constraints/DateConstraints.ts
@@ -16,32 +16,32 @@ function dateComparator(comparator: Comparator, name: DateConstraintName, expect
 }
 
 export function dateLt(value: Date): IConstraint<Date> {
-	const expected = `expected < ${value}`;
+	const expected = `expected < ${value.toISOString()}`;
 	return dateComparator(lt, 's.date.lt', expected, value.getTime());
 }
 
 export function dateLe(value: Date): IConstraint<Date> {
-	const expected = `expected <= ${value}`;
+	const expected = `expected <= ${value.toISOString()}`;
 	return dateComparator(le, 's.date.le', expected, value.getTime());
 }
 
 export function dateGt(value: Date): IConstraint<Date> {
-	const expected = `expected > ${value}`;
+	const expected = `expected > ${value.toISOString()}`;
 	return dateComparator(gt, 's.date.gt', expected, value.getTime());
 }
 
 export function dateGe(value: Date): IConstraint<Date> {
-	const expected = `expected >= ${value}`;
+	const expected = `expected >= ${value.toISOString()}`;
 	return dateComparator(ge, 's.date.ge', expected, value.getTime());
 }
 
 export function dateEq(value: Date): IConstraint<Date> {
-	const expected = `expected === ${value}`;
+	const expected = `expected === ${value.toISOString()}`;
 	return dateComparator(eq, 's.date.eq', expected, value.getTime());
 }
 
 export function dateNe(value: Date): IConstraint<Date> {
-	const expected = `expected !== ${value}`;
+	const expected = `expected !== ${value.toISOString()}`;
 	return dateComparator(ne, 's.date.ne', expected, value.getTime());
 }
 

--- a/src/validators/ArrayValidator.ts
+++ b/src/validators/ArrayValidator.ts
@@ -44,7 +44,7 @@ export class ArrayValidator<T> extends BaseValidator<T[]> {
 
 	protected handle(values: unknown): Result<T[], ValidationError | CombinedPropertyError> {
 		if (!Array.isArray(values)) {
-			return Result.err(new ValidationError('ArrayValidator', 'Expected an array', values));
+			return Result.err(new ValidationError('s.array(T)', 'Expected an array', values));
 		}
 
 		const errors: [number, BaseError][] = [];

--- a/src/validators/BaseValidator.ts
+++ b/src/validators/BaseValidator.ts
@@ -43,8 +43,8 @@ export abstract class BaseValidator<T> {
 		return this.addConstraint({ run: (input) => Result.ok(cb(input) as unknown as T) }) as unknown as BaseValidator<O>;
 	}
 
-	public default(value: T | (() => T)): DefaultValidator<T> {
-		return new DefaultValidator(this.clone(), value);
+	public default(value: Exclude<T, undefined> | (() => Exclude<T, undefined>)): DefaultValidator<Exclude<T, undefined>> {
+		return new DefaultValidator(this.clone() as unknown as BaseValidator<Exclude<T, undefined>>, value);
 	}
 
 	public run(value: unknown): Result<T, BaseError> {

--- a/src/validators/BigIntValidator.ts
+++ b/src/validators/BigIntValidator.ts
@@ -56,6 +56,6 @@ export class BigIntValidator<T extends bigint> extends BaseValidator<T> {
 	protected handle(value: unknown): Result<T, ValidationError> {
 		return typeof value === 'bigint' //
 			? Result.ok(value as T)
-			: Result.err(new ValidationError('BigIntValidator', 'Expected a bigint primitive', value));
+			: Result.err(new ValidationError('s.bigint', 'Expected a bigint primitive', value));
 	}
 }

--- a/src/validators/BooleanValidator.ts
+++ b/src/validators/BooleanValidator.ts
@@ -24,6 +24,6 @@ export class BooleanValidator<T extends boolean = boolean> extends BaseValidator
 	protected handle(value: unknown): Result<T, ValidationError> {
 		return typeof value === 'boolean' //
 			? Result.ok(value as T)
-			: Result.err(new ValidationError('BooleanValidator', 'Expected a boolean primitive', value));
+			: Result.err(new ValidationError('s.boolean', 'Expected a boolean primitive', value));
 	}
 }

--- a/src/validators/DateValidator.ts
+++ b/src/validators/DateValidator.ts
@@ -37,6 +37,6 @@ export class DateValidator extends BaseValidator<Date> {
 	protected handle(value: unknown): Result<Date, ValidationError> {
 		return value instanceof Date //
 			? Result.ok(value)
-			: Result.err(new ValidationError('DateValidator', 'Expected a Date', value));
+			: Result.err(new ValidationError('s.date', 'Expected a Date', value));
 	}
 }

--- a/src/validators/DefaultValidator.ts
+++ b/src/validators/DefaultValidator.ts
@@ -6,14 +6,20 @@ import { Result } from '../lib/Result';
 import { BaseValidator } from './imports';
 import { getValue } from './util/getValue';
 
-export class DefaultValidator<T> extends BaseValidator<T | undefined> {
+export class DefaultValidator<T> extends BaseValidator<T> {
 	private readonly validator: BaseValidator<T>;
-	private readonly defaultValue: T | (() => T);
+	private defaultValue: T | (() => T);
 
 	public constructor(validator: BaseValidator<T>, value: T | (() => T), constraints: readonly IConstraint<T>[] = []) {
 		super(constraints);
 		this.validator = validator;
 		this.defaultValue = value;
+	}
+
+	public override default(value: Exclude<T, undefined> | (() => Exclude<T, undefined>)): DefaultValidator<Exclude<T, undefined>> {
+		const clone = this.clone() as unknown as DefaultValidator<Exclude<T, undefined>>;
+		clone.defaultValue = value;
+		return clone;
 	}
 
 	protected handle(value: unknown): Result<T, ValidationError | CombinedError | CombinedPropertyError> {

--- a/src/validators/InstanceValidator.ts
+++ b/src/validators/InstanceValidator.ts
@@ -15,7 +15,7 @@ export class InstanceValidator<T> extends BaseValidator<T> {
 	protected handle(value: unknown): Result<T, ExpectedValidationError<Constructor<T>>> {
 		return value instanceof this.expected //
 			? Result.ok(value)
-			: Result.err(new ExpectedValidationError('InstanceValidator', 'Expected', value, this.expected));
+			: Result.err(new ExpectedValidationError('s.instance(V)', 'Expected', value, this.expected));
 	}
 
 	protected override clone(): this {

--- a/src/validators/LiteralValidator.ts
+++ b/src/validators/LiteralValidator.ts
@@ -14,7 +14,7 @@ export class LiteralValidator<T> extends BaseValidator<T> {
 	protected handle(value: unknown): Result<T, ExpectedValidationError<T>> {
 		return Object.is(value, this.expected) //
 			? Result.ok(value as T)
-			: Result.err(new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', value, this.expected));
+			: Result.err(new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', value, this.expected));
 	}
 
 	protected override clone(): this {

--- a/src/validators/MapValidator.ts
+++ b/src/validators/MapValidator.ts
@@ -21,7 +21,7 @@ export class MapValidator<K, V> extends BaseValidator<Map<K, V>> {
 
 	protected handle(value: unknown): Result<Map<K, V>, ValidationError | CombinedPropertyError> {
 		if (!(value instanceof Map)) {
-			return Result.err(new ValidationError('MapValidator', 'Expected a map', value));
+			return Result.err(new ValidationError('s.map(K, V)', 'Expected a map', value));
 		}
 
 		const errors: [string, BaseError][] = [];

--- a/src/validators/NeverValidator.ts
+++ b/src/validators/NeverValidator.ts
@@ -4,6 +4,6 @@ import { BaseValidator } from './imports';
 
 export class NeverValidator extends BaseValidator<never> {
 	protected handle(value: unknown): Result<never, ValidationError> {
-		return Result.err(new ValidationError('NeverValidator', 'Expected a value to not be passed', value));
+		return Result.err(new ValidationError('s.never', 'Expected a value to not be passed', value));
 	}
 }

--- a/src/validators/NullishValidator.ts
+++ b/src/validators/NullishValidator.ts
@@ -6,6 +6,6 @@ export class NullishValidator extends BaseValidator<undefined | null> {
 	protected handle(value: unknown): Result<undefined | null, ValidationError> {
 		return value === undefined || value === null //
 			? Result.ok(value)
-			: Result.err(new ValidationError('NullishValidator', 'Expected undefined or null', value));
+			: Result.err(new ValidationError('s.nullish', 'Expected undefined or null', value));
 	}
 }

--- a/src/validators/NumberValidator.ts
+++ b/src/validators/NumberValidator.ts
@@ -101,6 +101,6 @@ export class NumberValidator<T extends number> extends BaseValidator<T> {
 	protected handle(value: unknown): Result<T, ValidationError> {
 		return typeof value === 'number' //
 			? Result.ok(value as T)
-			: Result.err(new ValidationError('NumberValidator', 'Expected a number primitive', value));
+			: Result.err(new ValidationError('s.number', 'Expected a number primitive', value));
 	}
 }

--- a/src/validators/ObjectValidator.ts
+++ b/src/validators/ObjectValidator.ts
@@ -66,13 +66,11 @@ export class ObjectValidator<T extends NonNullObject> extends BaseValidator<T> {
 	protected override handle(value: unknown): Result<T, ValidationError | CombinedPropertyError> {
 		const typeOfValue = typeof value;
 		if (typeOfValue !== 'object') {
-			return Result.err(
-				new ValidationError('ObjectValidator', `Expected the value to be an object, but received ${typeOfValue} instead`, value)
-			);
+			return Result.err(new ValidationError('s.object(T)', `Expected the value to be an object, but received ${typeOfValue} instead`, value));
 		}
 
 		if (value === null) {
-			return Result.err(new ValidationError('ObjectValidator', 'Expected the value to not be null', value));
+			return Result.err(new ValidationError('s.object(T)', 'Expected the value to not be null', value));
 		}
 
 		return this.handleStrategy(value as NonNullObject);

--- a/src/validators/RecordValidator.ts
+++ b/src/validators/RecordValidator.ts
@@ -19,11 +19,11 @@ export class RecordValidator<T> extends BaseValidator<Record<string, T>> {
 
 	protected handle(value: unknown): Result<Record<string, T>, ValidationError | CombinedPropertyError> {
 		if (typeof value !== 'object') {
-			return Result.err(new ValidationError('RecordValidator', 'Expected an object', value));
+			return Result.err(new ValidationError('s.record(T)', 'Expected an object', value));
 		}
 
 		if (value === null) {
-			return Result.err(new ValidationError('RecordValidator', 'Expected the value to not be null', value));
+			return Result.err(new ValidationError('s.record(T)', 'Expected the value to not be null', value));
 		}
 
 		const errors: [string, BaseError][] = [];

--- a/src/validators/SetValidator.ts
+++ b/src/validators/SetValidator.ts
@@ -19,7 +19,7 @@ export class SetValidator<T> extends BaseValidator<Set<T>> {
 
 	protected handle(values: unknown): Result<Set<T>, ValidationError | CombinedError> {
 		if (!(values instanceof Set)) {
-			return Result.err(new ValidationError('SetValidator', 'Expected a set', values));
+			return Result.err(new ValidationError('s.set(T)', 'Expected a set', values));
 		}
 
 		const errors: BaseError[] = [];

--- a/src/validators/StringValidator.ts
+++ b/src/validators/StringValidator.ts
@@ -74,6 +74,6 @@ export class StringValidator<T extends string> extends BaseValidator<T> {
 	protected handle(value: unknown): Result<T, ValidationError> {
 		return typeof value === 'string' //
 			? Result.ok(value as T)
-			: Result.err(new ValidationError('StringValidator', 'Expected a string primitive', value));
+			: Result.err(new ValidationError('s.string', 'Expected a string primitive', value));
 	}
 }

--- a/tests/common/macros/comparators.ts
+++ b/tests/common/macros/comparators.ts
@@ -1,0 +1,90 @@
+import {
+	CombinedError,
+	CombinedPropertyError,
+	ConstraintError,
+	ExpectedValidationError,
+	MissingPropertyError,
+	UnknownPropertyError,
+	ValidationError,
+	type BaseError,
+	type BaseValidator
+} from '../../../src';
+
+export function expectClonedValidator<T>(expected: BaseValidator<T>, actual: BaseValidator<T>) {
+	expect(actual).not.toBe(expected);
+	expect(actual).toBeInstanceOf(expected.constructor);
+}
+
+export function expectIdenticalValidator<T>(expected: BaseValidator<T>, actual: BaseValidator<T>) {
+	expectClonedValidator(expected, actual);
+	expect(expected).toStrictEqual(actual);
+}
+
+export function expectModifiedClonedValidator<T>(expected: BaseValidator<T>, actual: BaseValidator<T>) {
+	expectClonedValidator(expected, actual);
+	expect(expected).not.toStrictEqual(actual);
+}
+
+export function expectError<T = any>(cb: () => T, expected: BaseError) {
+	try {
+		cb();
+		fail('expected to throw, but failed to do so');
+	} catch (error) {
+		expect(error).toBeDefined();
+		expectIdenticalError(error as BaseError, expected);
+		// expect(removeStack(error as Error)).toStrictEqual(removeStack(expected));
+	}
+}
+
+function expectIdenticalError(actual: BaseError, expected: BaseError) {
+	expect(actual.constructor).toBe(expected.constructor);
+	expect(actual.name).toBe(expected.name);
+	expect(actual.message).toBe(expected.message);
+
+	if (actual instanceof CombinedError) expectIdenticalCombinedError(actual, expected as CombinedError);
+	if (actual instanceof CombinedPropertyError) expectIdenticalCombinedPropertyError(actual, expected as CombinedPropertyError);
+	if (actual instanceof ConstraintError) expectIdenticalConstraintError(actual, expected as ConstraintError);
+	if (actual instanceof ExpectedValidationError) expectIdenticalExpectedValidationError(actual, expected as ExpectedValidationError<any>);
+	if (actual instanceof MissingPropertyError) expectIdenticalMissingPropertyError(actual, expected as MissingPropertyError);
+	if (actual instanceof UnknownPropertyError) expectIdenticalUnknownPropertyError(actual, expected as UnknownPropertyError);
+	if (actual instanceof ValidationError) expectIdenticalValidationError(actual, expected as ValidationError);
+}
+
+function expectIdenticalCombinedError(actual: CombinedError, expected: CombinedError) {
+	expect(actual.errors).toHaveLength(expected.errors.length);
+	for (let i = 0; i < actual.errors.length; ++i) {
+		expectIdenticalError(actual.errors[i], expected.errors[i]);
+	}
+}
+
+function expectIdenticalCombinedPropertyError(actual: CombinedPropertyError, expected: CombinedPropertyError) {
+	expect(actual.errors).toHaveLength(expected.errors.length);
+	for (let i = 0; i < actual.errors.length; ++i) {
+		expect(actual.errors[i][0]).toBe(expected.errors[i][0]);
+		expectIdenticalError(actual.errors[i][1], expected.errors[i][1]);
+	}
+}
+
+function expectIdenticalConstraintError(actual: ConstraintError, expected: ConstraintError) {
+	expect(actual.constraint).toBe(expected.constraint);
+	expect(actual.given).toStrictEqual(expected.given);
+	expect(actual.expected).toStrictEqual(expected.expected);
+}
+
+function expectIdenticalExpectedValidationError<T = any>(actual: ExpectedValidationError<T>, expected: ExpectedValidationError<T>) {
+	expect(actual.expected).toStrictEqual(expected.expected);
+}
+
+function expectIdenticalMissingPropertyError(actual: MissingPropertyError, expected: MissingPropertyError) {
+	expect(actual.property).toBe(expected.property);
+}
+
+function expectIdenticalUnknownPropertyError(actual: UnknownPropertyError, expected: UnknownPropertyError) {
+	expect(actual.property).toBe(expected.property);
+	expect(actual.value).toStrictEqual(expected.value);
+}
+
+function expectIdenticalValidationError(actual: ValidationError, expected: ValidationError) {
+	expect(actual.validator).toBe(expected.validator);
+	expect(actual.given).toStrictEqual(expected.given);
+}

--- a/tests/validators/bigint.test.ts
+++ b/tests/validators/bigint.test.ts
@@ -1,4 +1,5 @@
 import { ConstraintError, s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 const smallInteger = 42n;
 const largeInteger = 242043489611808769n;
@@ -11,7 +12,7 @@ describe('BigIntValidator', () => {
 	});
 
 	test('GIVEN a non-bigint THEN throws ValidationError', () => {
-		expect(() => predicate.parse('Hello there')).toThrow(new ValidationError('BigIntValidator', 'Expected a bigint primitive', 'Hello there'));
+		expectError(() => predicate.parse('Hello there'), new ValidationError('s.bigint', 'Expected a bigint primitive', 'Hello there'));
 	});
 
 	describe('Comparators', () => {
@@ -23,7 +24,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([42n, 100n])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => ltPredicate.parse(value)).toThrow(new ConstraintError('s.bigint.lt', 'Invalid bigint value', value, 'expected < 42n'));
+				expectError(() => ltPredicate.parse(value), new ConstraintError('s.bigint.lt', 'Invalid bigint value', value, 'expected < 42n'));
 			});
 		});
 
@@ -35,7 +36,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([100n])('GIVEN %d THEN throws ConstraintError', (input) => {
-				expect(() => lePredicate.parse(input)).toThrow(new ConstraintError('s.bigint.le', 'Invalid bigint value', input, 'expected <= 42n'));
+				expectError(() => lePredicate.parse(input), new ConstraintError('s.bigint.le', 'Invalid bigint value', input, 'expected <= 42n'));
 			});
 		});
 
@@ -47,7 +48,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([10n, 42n])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => gtPredicate.parse(value)).toThrow(new ConstraintError('s.bigint.gt', 'Invalid bigint value', value, 'expected > 42n'));
+				expectError(() => gtPredicate.parse(value), new ConstraintError('s.bigint.gt', 'Invalid bigint value', value, 'expected > 42n'));
 			});
 		});
 
@@ -59,7 +60,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([10n])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => gePredicate.parse(value)).toThrow(new ConstraintError('s.bigint.ge', 'Invalid bigint value', value, 'expected >= 42n'));
+				expectError(() => gePredicate.parse(value), new ConstraintError('s.bigint.ge', 'Invalid bigint value', value, 'expected >= 42n'));
 			});
 		});
 
@@ -71,7 +72,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([10n, 100n])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => eqPredicate.parse(value)).toThrow(new ConstraintError('s.bigint.eq', 'Invalid bigint value', value, 'expected === 42n'));
+				expectError(() => eqPredicate.parse(value), new ConstraintError('s.bigint.eq', 'Invalid bigint value', value, 'expected === 42n'));
 			});
 		});
 
@@ -83,7 +84,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([42n])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => nePredicate.parse(value)).toThrow(new ConstraintError('s.bigint.ne', 'Invalid bigint value', value, 'expected !== 42n'));
+				expectError(() => nePredicate.parse(value), new ConstraintError('s.bigint.ne', 'Invalid bigint value', value, 'expected !== 42n'));
 			});
 		});
 	});
@@ -97,7 +98,8 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([-smallInteger, -largeInteger])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => positivePredicate.parse(input)).toThrow(
+				expectError(
+					() => positivePredicate.parse(input),
 					new ConstraintError('s.bigint.ge', 'Invalid bigint value', input, 'expected >= 0n')
 				);
 			});
@@ -111,9 +113,7 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([smallInteger, largeInteger])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => positivePredicate.parse(input)).toThrow(
-					new ConstraintError('s.bigint.lt', 'Invalid bigint value', input, 'expected < 0n')
-				);
+				expectError(() => positivePredicate.parse(input), new ConstraintError('s.bigint.lt', 'Invalid bigint value', input, 'expected < 0n'));
 			});
 		});
 
@@ -125,7 +125,8 @@ describe('BigIntValidator', () => {
 			});
 
 			test.each([smallInteger, largeInteger, 6n])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => divisibleByPredicate.parse(input)).toThrow(
+				expectError(
+					() => divisibleByPredicate.parse(input),
 					new ConstraintError('s.bigint.divisibleBy', 'BigInt is not divisible', input, 'expected % 5n === 0n')
 				);
 			});

--- a/tests/validators/boolean.test.ts
+++ b/tests/validators/boolean.test.ts
@@ -1,4 +1,5 @@
 import { ConstraintError, s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('BooleanValidator', () => {
 	const predicate = s.boolean;
@@ -8,7 +9,7 @@ describe('BooleanValidator', () => {
 	});
 
 	test('GIVEN a non-boolean THEN throws ValidationError', () => {
-		expect(() => predicate.parse('Hello there')).toThrow(new ValidationError('BooleanValidator', 'Expected a boolean primitive', 'Hello there'));
+		expectError(() => predicate.parse('Hello there'), new ValidationError('s.boolean', 'Expected a boolean primitive', 'Hello there'));
 	});
 
 	describe('Comparators', () => {
@@ -21,9 +22,7 @@ describe('BooleanValidator', () => {
 			});
 
 			test('GIVEN false THEN throws ConstraintError', () => {
-				expect(() => eqPredicate.parse(false)).toThrow(
-					new ConstraintError('s.boolean.true', 'Invalid boolean value', false, 'expected === true')
-				);
+				expectError(() => eqPredicate.parse(false), new ConstraintError('s.boolean.true', 'Invalid boolean value', false, 'true'));
 			});
 		});
 
@@ -35,9 +34,7 @@ describe('BooleanValidator', () => {
 			});
 
 			test('GIVEN true THEN throws ConstraintError', () => {
-				expect(() => nePredicate.parse(true)).toThrow(
-					new ConstraintError('s.boolean.false', 'Invalid boolean value', true, 'expected !== true')
-				);
+				expectError(() => nePredicate.parse(true), new ConstraintError('s.boolean.false', 'Invalid boolean value', true, 'false'));
 			});
 		});
 	});
@@ -51,7 +48,7 @@ describe('BooleanValidator', () => {
 			});
 
 			test('GIVEN false THEN throws ConstraintError', () => {
-				expect(() => truePredicate.parse(false)).toThrow(new ConstraintError('s.boolean.true', 'Invalid boolean value', false, 'true'));
+				expectError(() => truePredicate.parse(false), new ConstraintError('s.boolean.true', 'Invalid boolean value', false, 'true'));
 			});
 		});
 
@@ -63,7 +60,7 @@ describe('BooleanValidator', () => {
 			});
 
 			test('GIVEN true THEN throws ConstraintError', () => {
-				expect(() => falsePredicate.parse(true)).toThrow(new ConstraintError('s.boolean.false', 'Invalid boolean value', true, 'false'));
+				expectError(() => falsePredicate.parse(true), new ConstraintError('s.boolean.false', 'Invalid boolean value', true, 'false'));
 			});
 		});
 	});

--- a/tests/validators/date.test.ts
+++ b/tests/validators/date.test.ts
@@ -1,4 +1,5 @@
 import { ConstraintError, s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('DateValidator', () => {
 	const predicate = s.date;
@@ -9,7 +10,7 @@ describe('DateValidator', () => {
 	});
 
 	test.each(['abc', '', null, undefined])('GIVEN a non-date THEN throws ValidationError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(new ValidationError('DateValidator', 'Expected a Date', input));
+		expectError(() => predicate.parse(input), new ValidationError('s.date', 'Expected a Date', input));
 	});
 
 	describe('Comparator', () => {
@@ -24,8 +25,9 @@ describe('DateValidator', () => {
 			});
 
 			test.each(datesInFuture)('GIVEN %s THEN throws ConstraintError', (value) => {
-				expect(() => ltPredicate.parse(value)).toThrow(
-					new ConstraintError('s.date.lt', 'Invalid Date value', value, 'expected < 2022-01-01')
+				expectError(
+					() => ltPredicate.parse(value),
+					new ConstraintError('s.date.lt', 'Invalid Date value', value, 'expected < 2022-02-01T00:00:00.000Z')
 				);
 			});
 		});
@@ -38,8 +40,9 @@ describe('DateValidator', () => {
 			});
 
 			test.each(datesInFuture)('GIVEN %s THEN throws ConstraintError', (value) => {
-				expect(() => lePredicate.parse(value)).toThrow(
-					new ConstraintError('s.date.le', 'Invalid Date value', value, 'expected <= 2022-01-01')
+				expectError(
+					() => lePredicate.parse(value),
+					new ConstraintError('s.date.le', 'Invalid Date value', value, 'expected <= 2022-02-01T00:00:00.000Z')
 				);
 			});
 		});
@@ -52,8 +55,9 @@ describe('DateValidator', () => {
 			});
 
 			test.each(datesInPast)('GIVEN %s THEN throws ConstraintError', (value) => {
-				expect(() => gtPredicate.parse(value)).toThrow(
-					new ConstraintError('s.date.gt', 'Invalid Date value', value, 'expected > 2022-01-01')
+				expectError(
+					() => gtPredicate.parse(value),
+					new ConstraintError('s.date.gt', 'Invalid Date value', value, 'expected > 2022-02-01T00:00:00.000Z')
 				);
 			});
 		});
@@ -66,8 +70,9 @@ describe('DateValidator', () => {
 			});
 
 			test.each(datesInPast)('GIVEN %s THEN throws ConstraintError', (value) => {
-				expect(() => gePredicate.parse(value)).toThrow(
-					new ConstraintError('s.date.ge', 'Invalid Date value', value, 'expected >= 2022-01-01')
+				expectError(
+					() => gePredicate.parse(value),
+					new ConstraintError('s.date.ge', 'Invalid Date value', value, 'expected >= 2022-02-01T00:00:00.000Z')
 				);
 			});
 		});
@@ -80,8 +85,9 @@ describe('DateValidator', () => {
 			});
 
 			test.each([...datesInPast, ...datesInFuture])('GIVEN %s THEN throws ConstraintError', (value) => {
-				expect(() => eqPredicate.parse(value)).toThrow(
-					new ConstraintError('s.date.eq', 'Invalid Date value', value, 'expected = 2022-01-02')
+				expectError(
+					() => eqPredicate.parse(value),
+					new ConstraintError('s.date.eq', 'Invalid Date value', value, 'expected === 2022-02-01T00:00:00.000Z')
 				);
 			});
 		});
@@ -94,7 +100,10 @@ describe('DateValidator', () => {
 			});
 
 			test('GIVEN date THEN throws ConstraintError', () => {
-				expect(() => nePredicate.parse(date)).toThrow(new ConstraintError('s.date.ne', 'Invalid Date value', date, 'expected != 2022-01-02'));
+				expectError(
+					() => nePredicate.parse(date),
+					new ConstraintError('s.date.ne', 'Invalid Date value', date, 'expected !== 2022-02-01T00:00:00.000Z')
+				);
 			});
 		});
 	});

--- a/tests/validators/enum.test.ts
+++ b/tests/validators/enum.test.ts
@@ -1,4 +1,5 @@
 import { CombinedError, ExpectedValidationError, s } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('EnumValidator', () => {
 	const predicate = s.enum('a', 'b', 'c');
@@ -8,11 +9,12 @@ describe('EnumValidator', () => {
 	});
 
 	test.each(['d', 'e', 'f', 1, null, true])('GIVEN a invalid value %s THEN throws CombinedError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(
+		expectError(
+			() => predicate.parse(input),
 			new CombinedError([
-				new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', input, 'a'),
-				new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', input, 'b'),
-				new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', input, 'c')
+				new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', input, 'a'),
+				new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', input, 'b'),
+				new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', input, 'c')
 			])
 		);
 	});

--- a/tests/validators/instance.test.ts
+++ b/tests/validators/instance.test.ts
@@ -1,4 +1,5 @@
 import { ExpectedValidationError, s } from '../../src';
+import { expectClonedValidator, expectError } from '../common/macros/comparators';
 
 describe('InstanceValidator', () => {
 	class User {
@@ -10,15 +11,12 @@ describe('InstanceValidator', () => {
 		expect(predicate.parse(new User('Sapphire'))).toStrictEqual(new User('Sapphire'));
 	});
 
-	test("GIVEN anything which isn't and instance of User THEN throws ValidationError", () => {
-		expect(() => predicate.parse(123)).toThrow(new ExpectedValidationError('InstanceValidator', 'Expected', 123, Array));
+	test('GIVEN anything which is not and instance of User THEN throws ValidationError', () => {
+		expectError(() => predicate.parse(123), new ExpectedValidationError('s.instance(V)', 'Expected', 123, User));
 	});
 
 	test('GIVEN clone THEN returns similar instance', () => {
-		// @ts-expect-error Test clone
-		const clonePredicate = predicate.clone();
-
-		expect(clonePredicate).toBeInstanceOf(predicate.constructor);
-		expect(clonePredicate.parse(new User('Sapphire'))).toStrictEqual(new User('Sapphire'));
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		expectClonedValidator(predicate, predicate['clone']());
 	});
 });

--- a/tests/validators/literal.test.ts
+++ b/tests/validators/literal.test.ts
@@ -1,4 +1,5 @@
 import { ExpectedValidationError, s } from '../../src';
+import { expectClonedValidator, expectError } from '../common/macros/comparators';
 
 describe('LiteralValidator', () => {
 	const predicate = s.literal('sapphire');
@@ -7,28 +8,17 @@ describe('LiteralValidator', () => {
 		expect(predicate.parse('sapphire')).toBe('sapphire');
 	});
 
-	test("GIVEN anything which isn't the literal THEN throws ExpectedValidationError", () => {
-		expect(() => predicate.parse('hello')).toThrow(
-			new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', 'hello', 'sapphire')
-		);
+	test('GIVEN anything which is not the literal THEN throws ExpectedValidationError', () => {
+		expectError(() => predicate.parse('hello'), new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', 'hello', 'sapphire'));
 	});
 
-	describe('DateLiteral', () => {
+	test('GIVEN date literal THEN returns s.date.eq(V)', () => {
 		const date = new Date('2022-01-01');
-		const dateLiteralPredicate = s.literal(date);
-		const datePredicate = s.date;
-
-		test('GIVEN a date literal THEN returns the given value', () => {
-			expect(dateLiteralPredicate.parse(date)).toStrictEqual(datePredicate.parse(date));
-			expect(dateLiteralPredicate.parse(date)).toStrictEqual(new Date('2022-01-01'));
-		});
+		expectClonedValidator(s.literal(date), s.date.eq(date));
 	});
 
 	test('GIVEN clone THEN returns similar instance', () => {
-		// @ts-expect-error Test clone
-		const clonePredicate = predicate.clone();
-
-		expect(clonePredicate).toBeInstanceOf(predicate.constructor);
-		expect(clonePredicate.parse('sapphire')).toBe('sapphire');
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		expectClonedValidator(predicate, predicate['clone']());
 	});
 });

--- a/tests/validators/never.test.ts
+++ b/tests/validators/never.test.ts
@@ -1,9 +1,10 @@
 import { s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('NeverValidator', () => {
 	const predicate = s.never;
 
 	test.each([123, 'hello'])('GIVEN a value THEN throws ConstraintError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(new ValidationError('NeverValidator', 'Expected a value to not be passed', input));
+		expectError(() => predicate.parse(input), new ValidationError('s.never', 'Expected a value to not be passed', input));
 	});
 });

--- a/tests/validators/null.test.ts
+++ b/tests/validators/null.test.ts
@@ -1,4 +1,5 @@
 import { ExpectedValidationError, s } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('NullValidator', () => {
 	const predicate = s.null;
@@ -8,6 +9,6 @@ describe('NullValidator', () => {
 	});
 
 	test.each([undefined, 123, 'Hello', {}])('GIVEN non-null %s THEN throws ExpectedValidationError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', input, null));
+		expectError(() => predicate.parse(input), new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', input, null));
 	});
 });

--- a/tests/validators/nullish.test.ts
+++ b/tests/validators/nullish.test.ts
@@ -1,4 +1,5 @@
 import { s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('NullishValidator', () => {
 	const predicate = s.nullish;
@@ -8,6 +9,6 @@ describe('NullishValidator', () => {
 	});
 
 	test.each([123, 'hello'])('GIVEN a value THEN throws ValidationError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(new ValidationError('NullishValidator', 'Expected undefined or null', input));
+		expectError(() => predicate.parse(input), new ValidationError('s.nullish', 'Expected undefined or null', input));
 	});
 });

--- a/tests/validators/number.test.ts
+++ b/tests/validators/number.test.ts
@@ -1,4 +1,5 @@
 import { ConstraintError, s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 const safeInteger = 42;
 // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
@@ -12,7 +13,7 @@ describe('NumberValidator', () => {
 	});
 
 	test('GIVEN a non-number THEN throws ValidationError', () => {
-		expect(() => predicate.parse('Hello there')).toThrow(new ValidationError('NumberValidator', 'Expected a number primitive', 'Hello there'));
+		expectError(() => predicate.parse('Hello there'), new ValidationError('s.number', 'Expected a number primitive', 'Hello there'));
 	});
 
 	describe('Comparators', () => {
@@ -24,7 +25,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([42, 100])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => ltPredicate.parse(value)).toThrow(new ConstraintError('s.number.lt', 'Invalid number value', value, 'expected < 42'));
+				expectError(() => ltPredicate.parse(value), new ConstraintError('s.number.lt', 'Invalid number value', value, 'expected < 42'));
 			});
 		});
 
@@ -36,7 +37,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([100])('GIVEN %d THEN throws ConstraintError', (input) => {
-				expect(() => lePredicate.parse(input)).toThrow(new ConstraintError('s.number.le', 'Invalid number value', input, 'expected <= 42'));
+				expectError(() => lePredicate.parse(input), new ConstraintError('s.number.le', 'Invalid number value', input, 'expected <= 42'));
 			});
 		});
 
@@ -48,7 +49,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([10, 42])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => gtPredicate.parse(value)).toThrow(new ConstraintError('s.number.gt', 'Invalid number value', value, 'expected > 42'));
+				expectError(() => gtPredicate.parse(value), new ConstraintError('s.number.gt', 'Invalid number value', value, 'expected > 42'));
 			});
 		});
 
@@ -60,7 +61,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([10])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => gePredicate.parse(value)).toThrow(new ConstraintError('s.number.ge', 'Invalid number value', value, 'expected >= 42'));
+				expectError(() => gePredicate.parse(value), new ConstraintError('s.number.ge', 'Invalid number value', value, 'expected >= 42'));
 			});
 		});
 
@@ -72,7 +73,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([10, 100])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => eqPredicate.parse(value)).toThrow(new ConstraintError('s.number.eq', 'Invalid number value', value, 'expected === 42'));
+				expectError(() => eqPredicate.parse(value), new ConstraintError('s.number.eq', 'Invalid number value', value, 'expected === 42'));
 			});
 		});
 
@@ -84,7 +85,8 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([safeInteger, unsafeInteger, 42.1, Infinity, -Infinity])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => eqNanPredicate.parse(input)).toThrow(
+				expectError(
+					() => eqNanPredicate.parse(input),
 					new ConstraintError('s.number.eq(NaN)', 'Invalid number value', input, 'expected === NaN')
 				);
 			});
@@ -98,7 +100,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([42])('GIVEN %d THEN throws ConstraintError', (value) => {
-				expect(() => nePredicate.parse(value)).toThrow(new ConstraintError('s.number.ne', 'Invalid number value', value, 'expected !== 42'));
+				expectError(() => nePredicate.parse(value), new ConstraintError('s.number.ne', 'Invalid number value', value, 'expected !== 42'));
 			});
 		});
 
@@ -110,7 +112,8 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => neNanPredicate.parse(input)).toThrow(
+				expectError(
+					() => neNanPredicate.parse(input),
 					new ConstraintError('s.number.ne(NaN)', 'Invalid number value', input, 'expected !== NaN')
 				);
 			});
@@ -126,8 +129,9 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([42.1, Infinity, NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => intPredicate.parse(input)).toThrow(
-					new ConstraintError('s.number.int', 'Given value is not an integer', input, 'Number.isInteger(expected)')
+				expectError(
+					() => intPredicate.parse(input),
+					new ConstraintError('s.number.int', 'Given value is not an integer', input, 'Number.isInteger(expected) to be true')
 				);
 			});
 		});
@@ -140,8 +144,9 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([unsafeInteger, 42.1, Infinity, NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => safeIntPredicate.parse(input)).toThrow(
-					new ConstraintError('s.number.safeInt', 'Given value is not a safe integer', input, 'Number.isSafeInteger(expected)')
+				expectError(
+					() => safeIntPredicate.parse(input),
+					new ConstraintError('s.number.safeInt', 'Given value is not a safe integer', input, 'Number.isSafeInteger(expected) to be true')
 				);
 			});
 		});
@@ -154,9 +159,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([-safeInteger, -unsafeInteger, -42.1, -Infinity])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => positivePredicate.parse(input)).toThrow(
-					new ConstraintError('s.number.ge', 'Invalid number value', input, 'expected >= 0')
-				);
+				expectError(() => positivePredicate.parse(input), new ConstraintError('s.number.ge', 'Invalid number value', input, 'expected >= 0'));
 			});
 		});
 
@@ -168,9 +171,7 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([safeInteger, unsafeInteger, 42.1, Infinity])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => positivePredicate.parse(input)).toThrow(
-					new ConstraintError('s.number.lt', 'Invalid number value', input, 'expected < 0')
-				);
+				expectError(() => positivePredicate.parse(input), new ConstraintError('s.number.lt', 'Invalid number value', input, 'expected < 0'));
 			});
 		});
 
@@ -182,8 +183,9 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([Infinity, -Infinity, NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => finitePredicate.parse(input)).toThrow(
-					new ConstraintError('s.number.finite', 'Given value is not finite', input, 'Number.isFinite(expected)')
+				expectError(
+					() => finitePredicate.parse(input),
+					new ConstraintError('s.number.finite', 'Given value is not finite', input, 'Number.isFinite(expected) to be true')
 				);
 			});
 		});
@@ -196,7 +198,8 @@ describe('NumberValidator', () => {
 			});
 
 			test.each([safeInteger, unsafeInteger, 6, 42.1, Infinity, -Infinity, NaN])('GIVEN %d THEN throws a ConstraintError', (input) => {
-				expect(() => divisibleByPredicate.parse(input)).toThrow(
+				expectError(
+					() => divisibleByPredicate.parse(input),
 					new ConstraintError('s.number.divisibleBy', 'Number is not divisible', input, 'expected % 5 === 0')
 				);
 			});

--- a/tests/validators/set.test.ts
+++ b/tests/validators/set.test.ts
@@ -1,10 +1,11 @@
 import { CombinedError, s, ValidationError } from '../../src';
+import { expectClonedValidator, expectError } from '../common/macros/comparators';
 
 describe('SetValidator', () => {
 	const predicate = s.set(s.string);
 
 	test.each([123, 'foo', [], {}, new Map()])("GIVEN a value which isn't a set %s THEN throws ValidationError", (input) => {
-		expect(() => predicate.parse(input)).toThrow(new ValidationError('SetValidator', 'Expected a set', input));
+		expectError(() => predicate.parse(input), new ValidationError('s.set(T)', 'Expected a set', input));
 	});
 
 	test.each(['1', 'a', 'foo'])('GIVEN a set with string value %s THEN returns the given set', (input) => {
@@ -16,14 +17,11 @@ describe('SetValidator', () => {
 	test.each([123, [], {}])('GIVEN a set with non-string value %s THEN throw CombinedError', (input) => {
 		const set = new Set([input]);
 
-		expect(() => predicate.parse(set)).toThrow(new CombinedError([new ValidationError('StringValidator', 'Expected a string', input)]));
+		expectError(() => predicate.parse(set), new CombinedError([new ValidationError('s.string', 'Expected a string primitive', input)]));
 	});
 
 	test('GIVEN clone THEN returns similar instance', () => {
-		// @ts-expect-error Test clone
-		const clonePredicate = predicate.clone();
-
-		expect(clonePredicate).toBeInstanceOf(predicate.constructor);
-		expect(clonePredicate.parse(new Set(['foo']))).toStrictEqual(predicate.parse(new Set(['foo'])));
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		expectClonedValidator(predicate, predicate['clone']());
 	});
 });

--- a/tests/validators/string.test.ts
+++ b/tests/validators/string.test.ts
@@ -1,4 +1,5 @@
 import { ConstraintError, s, ValidationError } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('StringValidator', () => {
 	const predicate = s.string;
@@ -8,7 +9,7 @@ describe('StringValidator', () => {
 	});
 
 	test('GIVEN a non-string THEN throws ValidationError', () => {
-		expect(() => predicate.parse(42)).toThrow(new ValidationError('StringValidator', 'Expected a string primitive', 42));
+		expectError(() => predicate.parse(42), new ValidationError('s.string', 'Expected a string primitive', 42));
 	});
 
 	describe('Comparators', () => {
@@ -20,7 +21,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Hello', 'Foo Bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthLtPredicate.parse(input)).toThrow(
+				expectError(
+					() => lengthLtPredicate.parse(input),
 					new ConstraintError('s.string.lengthLt', 'Invalid string length', input, 'expected.length < 5')
 				);
 			});
@@ -34,8 +36,9 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Foo Bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthLePredicate.parse(input)).toThrow(
-					new ConstraintError('s.string.lengthLt', 'Invalid string length', input, 'expected.length <= 5')
+				expectError(
+					() => lengthLePredicate.parse(input),
+					new ConstraintError('s.string.lengthLe', 'Invalid string length', input, 'expected.length <= 5')
 				);
 			});
 		});
@@ -48,7 +51,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Hi', 'Hello'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthGtPredicate.parse(input)).toThrow(
+				expectError(
+					() => lengthGtPredicate.parse(input),
 					new ConstraintError('s.string.lengthGt', 'Invalid string length', input, 'expected.length > 5')
 				);
 			});
@@ -62,7 +66,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Hi'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthGePredicate.parse(input)).toThrow(
+				expectError(
+					() => lengthGePredicate.parse(input),
 					new ConstraintError('s.string.lengthGe', 'Invalid string length', input, 'expected.length >= 5')
 				);
 			});
@@ -76,7 +81,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Hi', 'Foo Bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthEqPredicate.parse(input)).toThrow(
+				expectError(
+					() => lengthEqPredicate.parse(input),
 					new ConstraintError('s.string.lengthEq', 'Invalid string length', input, 'expected.length === 5')
 				);
 			});
@@ -90,8 +96,9 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['Hello'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => lengthNePredicate.parse(input)).toThrow(
-					new ConstraintError('s.string.lengthNe', 'Invalid string length', input, 'expected.length === 5')
+				expectError(
+					() => lengthNePredicate.parse(input),
+					new ConstraintError('s.string.lengthNe', 'Invalid string length', input, 'expected.length !== 5')
 				);
 			});
 		});
@@ -106,7 +113,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['hi@hello', 'foo@bar', 'foo@bar.com/', 'foo@bar.com/index?search=ok'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => emailPredicate.parse(input)).toThrow(
+				expectError(
+					() => emailPredicate.parse(input),
 					new ConstraintError('s.string.email', 'Invalid email address', input, 'expected to be an email address')
 				);
 			});
@@ -121,7 +129,10 @@ describe('StringValidator', () => {
 				});
 
 				test.each(['google.com', 'foo.bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => urlPredicate.parse(input)).toThrow(new ConstraintError('s.string.url', 'Invalid URL', input, 'expected.url'));
+					expectError(
+						() => urlPredicate.parse(input),
+						new ConstraintError('s.string.url', 'Invalid URL', input, 'expected to match an URL')
+					);
 				});
 			});
 
@@ -133,8 +144,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each(['https://google.com', 'http://foo.bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => urlPredicateWithProtocol.parse(input)).toThrow(
-						new ConstraintError('s.string.url', 'Invalid URL protocol', input, 'expected to be one of: git:')
+					expectError(
+						() => urlPredicateWithProtocol.parse(input),
+						new ConstraintError('s.string.url', 'Invalid URL protocol', input, `expected ${new URL(input).protocol} to be one of: git:`)
 					);
 				});
 			});
@@ -147,8 +159,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each(['https://foo.bar', 'http://foo.bar'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => urlPredicateWithDomain.parse(input)).toThrow(
-						new ConstraintError('s.string.url', 'Invalid URL domain', input, 'expected to be one of: google.com')
+					expectError(
+						() => urlPredicateWithDomain.parse(input),
+						new ConstraintError('s.string.url', 'Invalid URL domain', input, 'expected foo.bar to be one of: google.com')
 					);
 				});
 			});
@@ -170,8 +183,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each([uuid1, uuid3, uuid4])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => uuid5Predicate.parse(input)).toThrow(
-						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected UUID v5')
+					expectError(
+						() => uuid5Predicate.parse(input),
+						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected to match UUIDv5')
 					);
 				});
 			});
@@ -184,8 +198,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each([...invalidUuids, uuid5])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => uuid4Predicate.parse(input)).toThrow(
-						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected UUID v4')
+					expectError(
+						() => uuid4Predicate.parse(input),
+						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected to match UUIDv4')
 					);
 				});
 
@@ -196,8 +211,9 @@ describe('StringValidator', () => {
 					});
 
 					test.each([uuid1, ...invalidUuids])('GIVEN UUID other than v4 THEN throws a ConstraintError', (input) => {
-						expect(() => defaultPredicate.parse(input)).toThrow(
-							new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected UUID v4')
+						expectError(
+							() => defaultPredicate.parse(input),
+							new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected to match UUIDv4')
 						);
 					});
 				});
@@ -211,8 +227,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each([...invalidUuids, uuid4, uuid5])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => uuid3Predicate.parse(input)).toThrow(
-						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected UUID v3')
+					expectError(
+						() => uuid3Predicate.parse(input),
+						new ConstraintError('s.string.uuid', 'Invalid string format', input, 'expected to match UUIDv3')
 					);
 				});
 			});
@@ -225,8 +242,9 @@ describe('StringValidator', () => {
 				});
 
 				test.each([uuid5, nullUuid])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => uuidRangePredicate.parse(input)).toThrow(
-						new ConstraintError('s.string.uuid', 'Invalid string format', input, `expected UUID in range 1-4`)
+					expectError(
+						() => uuidRangePredicate.parse(input),
+						new ConstraintError('s.string.uuid', 'Invalid string format', input, `expected to match UUID in range of 1-4`)
 					);
 				});
 			});
@@ -248,7 +266,8 @@ describe('StringValidator', () => {
 			});
 
 			test.each(['ABC', '123A'])('GIVEN %s THEN throws a ConstraintError', (input) => {
-				expect(() => regexPredicate.parse(input)).toThrow(
+				expectError(
+					() => regexPredicate.parse(input),
 					new ConstraintError('s.string.regex', 'Invalid string format', input, `expected ${regex}.test(expected) to be true`)
 				);
 			});
@@ -272,7 +291,8 @@ describe('StringValidator', () => {
 				});
 
 				test.each(invalidIps)('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => ipPredicate.parse(input)).toThrow(
+					expectError(
+						() => ipPredicate.parse(input),
 						new ConstraintError('s.string.ip', 'Invalid ip address', input, 'expected to be an ip address')
 					);
 				});
@@ -286,7 +306,8 @@ describe('StringValidator', () => {
 				});
 
 				test.each([...v6Ips, ...invalidIps])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => ipv4Predicate.parse(input)).toThrow(
+					expectError(
+						() => ipv4Predicate.parse(input),
 						new ConstraintError('s.string.ipv4', 'Invalid ipv4 address', input, 'expected to be an ipv4 address')
 					);
 				});
@@ -300,7 +321,8 @@ describe('StringValidator', () => {
 				});
 
 				test.each([...v4Ips, ...invalidIps])('GIVEN %s THEN throws a ConstraintError', (input) => {
-					expect(() => ipv6Predicate.parse(input)).toThrow(
+					expectError(
+						() => ipv6Predicate.parse(input),
 						new ConstraintError('s.string.ipv6', 'Invalid ipv6 address', input, 'expected to be an ipv6 address')
 					);
 				});

--- a/tests/validators/undefined.test.ts
+++ b/tests/validators/undefined.test.ts
@@ -1,4 +1,5 @@
 import { ExpectedValidationError, s } from '../../src';
+import { expectError } from '../common/macros/comparators';
 
 describe('UndefinedValidator', () => {
 	const predicate = s.undefined;
@@ -8,8 +9,6 @@ describe('UndefinedValidator', () => {
 	});
 
 	test.each([null, 123, 'Hello'])('GIVEN %s THEN throws ExpectedValidationError', (input) => {
-		expect(() => predicate.parse(input)).toThrow(
-			new ExpectedValidationError('LiteralValidator', 'Expected values to be equals', input, undefined)
-		);
+		expectError(() => predicate.parse(input), new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', input, undefined));
 	});
 });

--- a/tests/validators/union.test.ts
+++ b/tests/validators/union.test.ts
@@ -1,21 +1,23 @@
-import { CombinedError, s, ValidationError } from '../../src';
+import { CombinedError, ExpectedValidationError, s, ValidationError } from '../../src';
+import { expectClonedValidator, expectError } from '../common/macros/comparators';
 
 describe('UnionValidator', () => {
 	const stringPredicate = s.string;
 	const numberPredicate = s.number;
 
-	const unionPredicate = s.union(stringPredicate, numberPredicate);
+	const predicate = s.union(stringPredicate, numberPredicate);
 
 	test('GIVEN a string THEN returns string', () => {
-		expect<string | number>(unionPredicate.parse('hello')).toBe('hello');
+		expect<string | number>(predicate.parse('hello')).toBe('hello');
 	});
 
 	test('GIVEN a number THEN returns number', () => {
-		expect<string | number>(unionPredicate.parse(5)).toBe(5);
+		expect<string | number>(predicate.parse(5)).toBe(5);
 	});
 
 	test('GIVEN a boolean THEN throw a ConstraintError', () => {
-		expect(() => unionPredicate.parse(true)).toThrow(
+		expectError(
+			() => predicate.parse(true),
 			new CombinedError([
 				new ValidationError('s.string', 'Expected a string primitive', true),
 				new ValidationError('s.number', 'Expected a number primitive', true)
@@ -24,68 +26,108 @@ describe('UnionValidator', () => {
 	});
 
 	describe('or', () => {
-		test('GIVEN string, number, array THEN return the input', () => {
-			const orPredicate = unionPredicate.or(s.union(s.string.array, s.number.array));
+		const orPredicate = predicate.or(s.string.array);
 
-			expect<string | number | string[] | number[]>(orPredicate.parse(['hello'])).toStrictEqual(['hello']);
-			expect(orPredicate.parse([5])).toStrictEqual([5]);
-			expect(orPredicate.parse('hello')).toBe('hello');
-			expect(orPredicate.parse(5)).toBe(5);
+		test.each([5, 'foo', ['bar']])('GIVEN %s THEN returns the input', (value) => {
+			expect<string | number | string[]>(orPredicate.parse(value)).toStrictEqual(value);
+		});
+
+		test.each([null, undefined, true])('GIVEN %s THEN throws CombinedError', (value) => {
+			expectError(
+				() => orPredicate.parse(value),
+				new CombinedError([
+					new ValidationError('s.string', 'Expected a string primitive', value),
+					new ValidationError('s.number', 'Expected a number primitive', value),
+					new ValidationError('s.array(T)', 'Expected an array', value)
+				])
+			);
+		});
+
+		test('GIVEN s.union(s.string, s.number).or(s.string.array) THEN returns s.union(s.string, s.number, s.string.array)', () => {
+			expectClonedValidator(orPredicate, s.union(s.string, s.number, s.string.array));
 		});
 	});
 
-	test('optional', () => {
-		const optionalPredicate = unionPredicate.optional;
+	describe('optional', () => {
+		const optionalPredicate = predicate.optional;
 
-		expect<string | number | undefined>(optionalPredicate.parse(undefined)).toBeUndefined();
-		expect(optionalPredicate.parse('hello')).toBe('hello');
-		expect(optionalPredicate.parse(5)).toBe(5);
+		test.each([undefined, 'hello', 5])('GIVEN %s THEN returns %s', (value) => {
+			expect<string | number | undefined>(optionalPredicate.parse(value)).toBe(value);
+		});
 
-		expect(() => optionalPredicate.parse(null)).toThrow(
-			new CombinedError([
-				new ValidationError('s.string', 'Expected a string primitive', null),
-				new ValidationError('s.number', 'Expected a number primitive', null)
-			])
-		);
+		test.each([null, true, {}])('GIVEN %s THEN throws CombinedError', (value) => {
+			expectError(
+				() => optionalPredicate.parse(value),
+				new CombinedError([
+					new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', value, undefined),
+					new CombinedError([
+						new ValidationError('s.string', 'Expected a string primitive', value),
+						new ValidationError('s.number', 'Expected a number primitive', value)
+					])
+				])
+			);
+		});
+
+		// TODO: Fix
+		test.skip('GIVEN s.union(s.string, s.number).optional THEN returns s.union(s.undefined, s.string, s.number)', () => {
+			expectClonedValidator(optionalPredicate, s.union(s.undefined, s.string, s.number));
+		});
 	});
 
-	test('nullable', () => {
-		const nullablePredicate = unionPredicate.nullable;
+	describe('nullable', () => {
+		const nullablePredicate = predicate.nullable;
 
-		expect<string | number | null>(nullablePredicate.parse(null)).toBeNull();
-		expect(nullablePredicate.parse('hello')).toBe('hello');
-		expect(nullablePredicate.parse(5)).toBe(5);
+		test.each([null, 'hello', 5])('GIVEN %s THEN returns %s', (value) => {
+			expect<string | number | null>(nullablePredicate.parse(value)).toBe(value);
+		});
 
-		expect(() => nullablePredicate.parse(undefined)).toThrow(
-			new CombinedError([
-				new ValidationError('s.string', 'Expected a string primitive', undefined),
-				new ValidationError('s.number', 'Expected a number primitive', undefined)
-			])
-		);
+		test.each([undefined, true, {}])('GIVEN %s THEN throws CombinedError', (value) => {
+			expectError(
+				() => nullablePredicate.parse(value),
+				new CombinedError([
+					new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', value, null),
+					new CombinedError([
+						new ValidationError('s.string', 'Expected a string primitive', value),
+						new ValidationError('s.number', 'Expected a number primitive', value)
+					])
+				])
+			);
+		});
+
+		// TODO: Fix
+		test.skip('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
+			expectClonedValidator(nullablePredicate, s.union(s.null, s.string, s.number));
+		});
 	});
 
-	test('nullish', () => {
-		const nullishPredicate = unionPredicate.nullish;
+	describe('nullish', () => {
+		const nullishPredicate = predicate.nullish;
 
-		expect<string | number | undefined | null>(nullishPredicate.parse(null)).toBeNull();
-		expect(nullishPredicate.parse('hello')).toBe('hello');
-		expect(nullishPredicate.parse(5)).toBe(5);
-		expect(nullishPredicate.parse(undefined)).toBeUndefined();
+		test.each([null, undefined, 'hello', 5])('GIVEN %s THEN returns %s', (value) => {
+			expect<string | number | undefined | null>(nullishPredicate.parse(value)).toBe(value);
+		});
 
-		expect(() => nullishPredicate.parse(false)).toThrow(
-			new CombinedError([
-				new ValidationError('s.string', 'Expected a string primitive', false),
-				new ValidationError('s.number', 'Expected a number primitive', false)
-			])
-		);
+		test.each([true, {}])('GIVEN %s THEN throws CombinedError', (value) => {
+			expectError(
+				() => nullishPredicate.parse(value),
+				new CombinedError([
+					new ValidationError('s.nullish', 'Expected undefined or null', value),
+					new CombinedError([
+						new ValidationError('s.string', 'Expected a string primitive', value),
+						new ValidationError('s.number', 'Expected a number primitive', value)
+					])
+				])
+			);
+		});
+
+		// TODO: Fix
+		test.skip('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
+			expectClonedValidator(nullishPredicate, s.union(s.null, s.string, s.number));
+		});
 	});
 
 	test('GIVEN clone THEN returns similar instance', () => {
-		// @ts-expect-error Test clone
-		const clonePredicate = unionPredicate.clone();
-
-		expect(clonePredicate).toBeInstanceOf(unionPredicate.constructor);
-		expect(clonePredicate.parse('hello')).toBe(unionPredicate.parse('hello'));
-		expect(clonePredicate.parse(5)).toBe(unionPredicate.parse(5));
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		expectClonedValidator(predicate, predicate['clone']());
 	});
 });


### PR DESCRIPTION
This makes testing a lot easier by abstracting many checks that would otherwise require a lot of code in the unit tests.
