### PR TITLE
feat(Array): generate tuple types with given length

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ s.string.array.lengthEq(5); // Must have exactly 5 elements
 s.string.array.lengthNe(5); // Must not have exactly 5 elements
 ```
 
-> **Note**: `.lengthGt` and `.lengthGe` are overloaded and change the inferred type from 1 to 10. For example, `s.string.array.lengthGe(2)`'s inferred type is `[string, string, ...string[]]` // TODO
+> **Note**: All `.length` methods define tuple types with the given amount of elements. For example, `s.string.array.lengthGe(2)`'s inferred type is `[string, string, ...string[]]`
 
 #### Tuples
 

--- a/src/lib/Shapes.ts
+++ b/src/lib/Shapes.ts
@@ -82,7 +82,7 @@ export class Shapes {
 		return new InstanceValidator(expected);
 	}
 
-	public union<T extends [...BaseValidator<any>[]]>(...validators: [...T]): UnionValidator<T[number] extends BaseValidator<infer U> ? U : never> {
+	public union<T extends [...BaseValidator<any>[]]>(...validators: [...T]): UnionValidator<Unwrap<T[number]>> {
 		return new UnionValidator(validators);
 	}
 
@@ -107,6 +107,5 @@ export class Shapes {
 	}
 }
 
-type UnwrapTuple<T extends [...any[]]> = T extends [infer Head, ...infer Tail]
-	? [Head extends BaseValidator<infer V> ? V : never, ...UnwrapTuple<Tail>]
-	: [];
+type UnwrapTuple<T extends [...any[]]> = T extends [infer Head, ...infer Tail] ? [Unwrap<Head>, ...UnwrapTuple<Tail>] : [];
+export type Unwrap<T> = T extends BaseValidator<infer V> ? V : never;

--- a/src/type-exports.ts
+++ b/src/type-exports.ts
@@ -7,13 +7,13 @@ export type {
 	arrayLengthLt,
 	arrayLengthNe,
 	BigIntConstraintName,
+	bigintDivisibleBy,
 	bigintEq,
 	bigintGe,
 	bigintGt,
 	bigintLe,
 	bigintLt,
 	bigintNe,
-	bigintDivisibleBy,
 	BooleanConstraintName,
 	booleanFalse,
 	booleanTrue,
@@ -57,7 +57,7 @@ export type { MissingPropertyError } from './lib/errors/MissingPropertyError';
 export type { UnknownPropertyError } from './lib/errors/UnknownPropertyError';
 export type { ValidationError } from './lib/errors/ValidationError';
 //
-export type { Shapes } from './lib/Shapes';
+export type { Shapes, Unwrap } from './lib/Shapes';
 //
 export type { Constructor, MappedObjectValidator, NonNullObject, Type } from './lib/util-types';
 //

--- a/src/validators/ArrayValidator.ts
+++ b/src/validators/ArrayValidator.ts
@@ -14,27 +14,27 @@ export class ArrayValidator<T> extends BaseValidator<T[]> {
 		this.validator = validator;
 	}
 
-	public lengthLt(length: number): this {
-		return this.addConstraint(arrayLengthLt(length) as IConstraint<T[]>);
+	public lengthLt<N extends number>(length: N): BaseValidator<ExpandSmallerTuples<UnshiftTuple<[...Tuple<T, N>]>>> {
+		return this.addConstraint(arrayLengthLt(length) as IConstraint<T[]>) as any;
 	}
 
-	public lengthLe(length: number): this {
-		return this.addConstraint(arrayLengthLe(length) as IConstraint<T[]>);
+	public lengthLe<N extends number>(length: N): BaseValidator<ExpandSmallerTuples<[...Tuple<T, N>]>> {
+		return this.addConstraint(arrayLengthLe(length) as IConstraint<T[]>) as any;
 	}
 
-	public lengthGt(length: number): this {
-		return this.addConstraint(arrayLengthGt(length) as IConstraint<T[]>);
+	public lengthGt<N extends number>(length: N): BaseValidator<[...Tuple<T, N>, T, ...T[]]> {
+		return this.addConstraint(arrayLengthGt(length) as IConstraint<T[]>) as any;
 	}
 
-	public lengthGe(length: number): this {
-		return this.addConstraint(arrayLengthGe(length) as IConstraint<T[]>);
+	public lengthGe<N extends number>(length: N): BaseValidator<[...Tuple<T, N>, ...T[]]> {
+		return this.addConstraint(arrayLengthGe(length) as IConstraint<T[]>) as any;
 	}
 
-	public lengthEq(length: number): this {
-		return this.addConstraint(arrayLengthEq(length) as IConstraint<T[]>);
+	public lengthEq<N extends number>(length: N): BaseValidator<[...Tuple<T, N>]> {
+		return this.addConstraint(arrayLengthEq(length) as IConstraint<T[]>) as any;
 	}
 
-	public lengthNe(length: number): this {
+	public lengthNe(length: number): BaseValidator<[...T[]]> {
 		return this.addConstraint(arrayLengthNe(length) as IConstraint<T[]>);
 	}
 
@@ -61,3 +61,19 @@ export class ArrayValidator<T> extends BaseValidator<T[]> {
 			: Result.err(new CombinedPropertyError(errors));
 	}
 }
+
+type UnshiftTuple<T extends [...any[]]> = T extends [T[0], ...infer Tail] ? Tail : never;
+type ExpandSmallerTuples<T extends [...any[]]> = T extends [T[0], ...infer Tail] ? T | ExpandSmallerTuples<Tail> : [];
+
+// https://github.com/microsoft/TypeScript/issues/26223#issuecomment-755067958
+type Shift<A extends Array<any>> = ((...args: A) => void) extends (...args: [A[0], ...infer R]) => void ? R : never;
+
+type GrowExpRev<A extends Array<any>, N extends number, P extends Array<Array<any>>> = A['length'] extends N
+	? A
+	: GrowExpRev<[...A, ...P[0]][N] extends undefined ? [...A, ...P[0]] : A, N, Shift<P>>;
+
+type GrowExp<A extends Array<any>, N extends number, P extends Array<Array<any>>> = [...A, ...A][N] extends undefined
+	? GrowExp<[...A, ...A], N, [A, ...P]>
+	: GrowExpRev<A, N, P>;
+
+type Tuple<T, N extends number> = number extends N ? Array<T> : N extends 0 ? [] : N extends 1 ? [T] : GrowExp<[T], N, [[]]>;

--- a/tests/validators/array.test.ts
+++ b/tests/validators/array.test.ts
@@ -5,7 +5,7 @@ describe('ArrayValidator', () => {
 	const predicate = s.string.array;
 
 	test('GIVEN an array THEN returns an array', () => {
-		expect(predicate.parse(['Hello', 'there'])).toEqual(['Hello', 'there']);
+		expect<string[]>(predicate.parse(['Hello', 'there'])).toEqual(['Hello', 'there']);
 	});
 
 	test('GIVEN a non-array THEN throws ValidationError', () => {
@@ -23,29 +23,14 @@ describe('ArrayValidator', () => {
 	});
 
 	describe('Comparators', () => {
-		describe('length', () => {
-			const lengthPredicate = s.string.array.lengthEq(2);
-
-			test.each([[['Hello', 'there']]])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthPredicate.parse(value)).toEqual(value);
-			});
-
-			test.each<any[]>([[[], ['Hello']]])('GIVEN %p THEN throws ConstraintError', (value) => {
-				expectError(
-					() => lengthPredicate.parse(value),
-					new ConstraintError('s.array(T).lengthEq', 'Invalid Array length', value, 'expected.length === 2')
-				);
-			});
-		});
-
 		describe('lengthLt', () => {
 			const lengthLtPredicate = s.string.array.lengthLt(2);
 
 			test.each([[['Hello']]])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthLtPredicate.parse(value)).toEqual(value);
+				expect<[string] | []>(lengthLtPredicate.parse(value)).toEqual(value);
 			});
 
-			test.each<any[]>([
+			test.each([
 				[
 					['Hello', 'there'],
 					['foo', 'bar', 'baaz']
@@ -61,11 +46,11 @@ describe('ArrayValidator', () => {
 		describe('lengthLe', () => {
 			const lengthLePredicate = s.string.array.lengthLe(2);
 
-			test.each<any[]>([[['Hello'], ['Hello', 'there']]])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthLePredicate.parse(value)).toEqual(value);
+			test.each([[['Hello'], ['Hello', 'there']]])('GIVEN %p THEN returns given value', (value) => {
+				expect<[string, string] | [string] | []>(lengthLePredicate.parse(value)).toEqual(value);
 			});
 
-			test.each<any[]>([[['foo', 'bar', 'baaz']]])('GIVEN %p THEN throws ConstraintError', (value) => {
+			test.each([[['foo', 'bar', 'baaz']]])('GIVEN %p THEN throws ConstraintError', (value) => {
 				expectError(
 					() => lengthLePredicate.parse(value),
 					new ConstraintError('s.array(T).lengthLe', 'Invalid Array length', value, 'expected.length <= 2')
@@ -77,10 +62,10 @@ describe('ArrayValidator', () => {
 			const lengthGtPredicate = s.string.array.lengthGt(2);
 
 			test.each([[['foo', 'bar', 'baaz']]])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthGtPredicate.parse(value)).toEqual(value);
+				expect<[string, string, string, ...string[]]>(lengthGtPredicate.parse(value)).toEqual(value);
 			});
 
-			test.each<any[]>([[['Hello'], []]])('GIVEN %p THEN throws ConstraintError', (value) => {
+			test.each([[['Hello'], []]])('GIVEN %p THEN throws ConstraintError', (value) => {
 				expectError(
 					() => lengthGtPredicate.parse(value),
 					new ConstraintError('s.array(T).lengthGt', 'Invalid Array length', value, 'expected.length > 2')
@@ -91,16 +76,16 @@ describe('ArrayValidator', () => {
 		describe('lengthGe', () => {
 			const lengthGePredicate = s.string.array.lengthGe(2);
 
-			test.each<any[]>([
+			test.each([
 				[
 					['Hello', 'there'],
 					['foo', 'bar', 'baaz']
 				]
 			])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthGePredicate.parse(value)).toEqual(value);
+				expect<[string, string, ...string[]]>(lengthGePredicate.parse(value)).toEqual(value);
 			});
 
-			test.each<any[]>([[[], ['foo']]])('GIVEN %p THEN throws ConstraintError', (value) => {
+			test.each([[[], ['foo']]])('GIVEN %p THEN throws ConstraintError', (value) => {
 				expectError(
 					() => lengthGePredicate.parse(value),
 					new ConstraintError('s.array(T).lengthGe', 'Invalid Array length', value, 'expected.length >= 2')
@@ -108,14 +93,29 @@ describe('ArrayValidator', () => {
 			});
 		});
 
+		describe('lengthEq', () => {
+			const lengthPredicate = s.string.array.lengthEq(2);
+
+			test.each([[['Hello', 'there']]])('GIVEN %p THEN returns given value', (value) => {
+				expect<[string, string]>(lengthPredicate.parse(value)).toEqual(value);
+			});
+
+			test.each([[[], ['Hello']]])('GIVEN %p THEN throws ConstraintError', (value) => {
+				expectError(
+					() => lengthPredicate.parse(value),
+					new ConstraintError('s.array(T).lengthEq', 'Invalid Array length', value, 'expected.length === 2')
+				);
+			});
+		});
+
 		describe('lengthNe', () => {
 			const lengthNotEqPredicate = s.string.array.lengthNe(2);
 
-			test.each<any[]>([[['foo', 'bar', 'baaz'], ['foo']]])('GIVEN %p THEN returns given value', (value) => {
-				expect(lengthNotEqPredicate.parse(value)).toEqual(value);
+			test.each([[['foo', 'bar', 'baaz'], ['foo']]])('GIVEN %p THEN returns given value', (value) => {
+				expect<string[]>(lengthNotEqPredicate.parse(value)).toEqual(value);
 			});
 
-			test.each<any[]>([
+			test.each([
 				[
 					['Hello', 'there'],
 					['foo', 'bar']


### PR DESCRIPTION
I used `as any` casts to silence the compiler complaining about `T` types not matching.

Also tried to avoid overload hell... by making use of TypeScript 4.1+ features.