### PR TITLE
fix(s.union): fix union overrides

### DIFF
--- a/src/validators/UnionValidator.ts
+++ b/src/validators/UnionValidator.ts
@@ -64,7 +64,7 @@ export class UnionValidator<T> extends BaseValidator<T> {
 
 		const [validator] = this.validators;
 		if (validator instanceof LiteralValidator) {
-			// If already nullable, return a clone:
+			// If already nullable or optional, promote the union to nullish:
 			if (validator.expected === null || validator.expected === undefined) {
 				return new UnionValidator<T | null | undefined>([new NullishValidator(), ...this.validators.slice(1)], this.constraints);
 			}

--- a/tests/validators/union.test.ts
+++ b/tests/validators/union.test.ts
@@ -69,6 +69,14 @@ describe('UnionValidator', () => {
 		test('GIVEN s.union(s.string, s.number).optional THEN returns s.union(s.undefined, s.string, s.number)', () => {
 			expectClonedValidator(optionalPredicate, s.union(s.undefined, s.string, s.number));
 		});
+
+		describe('nullish', () => {
+			const nullishPredicate = optionalPredicate.nullish;
+
+			test('GIVEN s.union(s.string, s.number).nullable.nullish THEN returns s.union(s.nullish, s.string, s.number)', () => {
+				expectClonedValidator(nullishPredicate, s.union(s.nullish, s.string, s.number));
+			});
+		});
 	});
 
 	describe('nullable', () => {
@@ -91,6 +99,14 @@ describe('UnionValidator', () => {
 
 		test('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
 			expectClonedValidator(nullablePredicate, s.union(s.null, s.string, s.number));
+		});
+
+		describe('nullish', () => {
+			const nullishPredicate = nullablePredicate.nullish;
+
+			test('GIVEN s.union(s.string, s.number).nullable.nullish THEN returns s.union(s.nullish, s.string, s.number)', () => {
+				expectClonedValidator(nullishPredicate, s.union(s.nullish, s.string, s.number));
+			});
 		});
 	});
 

--- a/tests/validators/union.test.ts
+++ b/tests/validators/union.test.ts
@@ -60,16 +60,13 @@ describe('UnionValidator', () => {
 				() => optionalPredicate.parse(value),
 				new CombinedError([
 					new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', value, undefined),
-					new CombinedError([
-						new ValidationError('s.string', 'Expected a string primitive', value),
-						new ValidationError('s.number', 'Expected a number primitive', value)
-					])
+					new ValidationError('s.string', 'Expected a string primitive', value),
+					new ValidationError('s.number', 'Expected a number primitive', value)
 				])
 			);
 		});
 
-		// TODO: Fix
-		test.skip('GIVEN s.union(s.string, s.number).optional THEN returns s.union(s.undefined, s.string, s.number)', () => {
+		test('GIVEN s.union(s.string, s.number).optional THEN returns s.union(s.undefined, s.string, s.number)', () => {
 			expectClonedValidator(optionalPredicate, s.union(s.undefined, s.string, s.number));
 		});
 	});
@@ -86,16 +83,13 @@ describe('UnionValidator', () => {
 				() => nullablePredicate.parse(value),
 				new CombinedError([
 					new ExpectedValidationError('s.literal(V)', 'Expected values to be equals', value, null),
-					new CombinedError([
-						new ValidationError('s.string', 'Expected a string primitive', value),
-						new ValidationError('s.number', 'Expected a number primitive', value)
-					])
+					new ValidationError('s.string', 'Expected a string primitive', value),
+					new ValidationError('s.number', 'Expected a number primitive', value)
 				])
 			);
 		});
 
-		// TODO: Fix
-		test.skip('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
+		test('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
 			expectClonedValidator(nullablePredicate, s.union(s.null, s.string, s.number));
 		});
 	});
@@ -112,16 +106,13 @@ describe('UnionValidator', () => {
 				() => nullishPredicate.parse(value),
 				new CombinedError([
 					new ValidationError('s.nullish', 'Expected undefined or null', value),
-					new CombinedError([
-						new ValidationError('s.string', 'Expected a string primitive', value),
-						new ValidationError('s.number', 'Expected a number primitive', value)
-					])
+					new ValidationError('s.string', 'Expected a string primitive', value),
+					new ValidationError('s.number', 'Expected a number primitive', value)
 				])
 			);
 		});
 
-		// TODO: Fix
-		test.skip('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
+		test('GIVEN s.union(s.string, s.number).nullable THEN returns s.union(s.null, s.string, s.number)', () => {
 			expectClonedValidator(nullishPredicate, s.union(s.null, s.string, s.number));
 		});
 	});


### PR DESCRIPTION
The overridden methods were not supposed to nest UnionValidators
