### PR TITLE
feat(s.object): add passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ person.parse({
 
 You can use the `.ignore` getter to reset an object schema to the default behaviour (ignoring unrecognized keys).
 
+##### `.passthrough`
+
+You can use the `.passthrough` getter to make the validator add the unrecognized properties the shape does not have, from the input.
+
 #### Records
 
 Record schemas are similar to objects, but validate `Record<string, T>` types, keep in mind this does not check for the keys, and cannot support validation for specific ones:

--- a/tests/validators/object.test.ts
+++ b/tests/validators/object.test.ts
@@ -114,6 +114,25 @@ describe('ObjectValidator', () => {
 		});
 	});
 
+	describe('Passthrough', () => {
+		const passthroughPredicate = predicate.strict.passthrough;
+
+		test('GIVEN matching keys and values THEN returns no errors', () => {
+			expect(passthroughPredicate.parse({ username: 'Sapphire', password: 'helloworld', email: 'foo@bar.com' })).toStrictEqual({
+				email: 'foo@bar.com',
+				username: 'Sapphire',
+				password: 'helloworld'
+			});
+		});
+
+		test('GIVEN missing keys THEN throws CombinedPropertyError with MissingPropertyError', () => {
+			expectError(
+				() => passthroughPredicate.parse({ username: 'Sapphire' }),
+				new CombinedPropertyError([['password', new MissingPropertyError('password')]])
+			);
+		});
+	});
+
 	describe('Partial', () => {
 		const partialPredicate = predicate.partial;
 

--- a/tests/validators/object.test.ts
+++ b/tests/validators/object.test.ts
@@ -97,7 +97,7 @@ describe('ObjectValidator', () => {
 	});
 
 	describe('Ignore', () => {
-		const ignorePredicate = predicate.strict.ignore;
+		const ignorePredicate = predicate.ignore;
 
 		test('GIVEN matching keys and values THEN returns no errors', () => {
 			expect(ignorePredicate.parse({ username: 'Sapphire', password: 'helloworld', email: 'foo@bar.com' })).toStrictEqual({
@@ -115,7 +115,7 @@ describe('ObjectValidator', () => {
 	});
 
 	describe('Passthrough', () => {
-		const passthroughPredicate = predicate.strict.passthrough;
+		const passthroughPredicate = predicate.passthrough;
 
 		test('GIVEN matching keys and values THEN returns no errors', () => {
 			expect(passthroughPredicate.parse({ username: 'Sapphire', password: 'helloworld', email: 'foo@bar.com' })).toStrictEqual({


### PR DESCRIPTION
One last thing Zod has that Shapeshift didn't yet, [`s.object.passthrough`](https://www.npmjs.com/package/zod#passthrough).
