### PR TITLE
test: increase test coverage for email validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
 		"**/.yarn": true,
 		"**/dist/": true,
 		"**/.git/": true
-	}
+	},
+	"cSpell.words": ["bortzmeyer", "fhqwhgads", "manisharaan", "midichlorians", "Pallas", "Plagueis"]
 }

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -6,6 +6,7 @@ const config = {
 	testRunner: 'jest-circus/runner',
 	testMatch: ['<rootDir>/tests/**/*.test.ts'],
 	collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+	setupFilesAfterEnv: ['<rootDir>/tests/jest.setup.ts'],
 	globals: {
 		'ts-jest': {
 			tsconfig: '<rootDir>/tests/tsconfig.json'

--- a/tests/common/macros/comparators.ts
+++ b/tests/common/macros/comparators.ts
@@ -29,7 +29,7 @@ export function expectModifiedClonedValidator<T>(expected: BaseValidator<T>, act
 export function expectError<T = any>(cb: () => T, expected: BaseError) {
 	try {
 		cb();
-		fail('expected to throw, but failed to do so');
+		fail();
 	} catch (error) {
 		expect(error).toBeDefined();
 		expectIdenticalError(error as BaseError, expected);

--- a/tests/common/macros/comparators.ts
+++ b/tests/common/macros/comparators.ts
@@ -29,12 +29,13 @@ export function expectModifiedClonedValidator<T>(expected: BaseValidator<T>, act
 export function expectError<T = any>(cb: () => T, expected: BaseError) {
 	try {
 		cb();
-		fail();
 	} catch (error) {
 		expect(error).toBeDefined();
 		expectIdenticalError(error as BaseError, expected);
-		// expect(removeStack(error as Error)).toStrictEqual(removeStack(expected));
+		return;
 	}
+
+	fail('Expected to throw, but failed to do so');
 }
 
 function expectIdenticalError(actual: BaseError, expected: BaseError) {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,0 +1,5 @@
+function fail(reason = 'Expected to throw, but failed to do so') {
+	throw new Error(reason);
+}
+
+global.fail = fail;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,5 +1,5 @@
-function fail(reason = 'Expected to throw, but failed to do so') {
+function fail(reason = 'fail was called in a test.') {
 	throw new Error(reason);
 }
 
-global.fail = fail;
+global.fail ??= fail;

--- a/tests/validators/string.test.ts
+++ b/tests/validators/string.test.ts
@@ -112,11 +112,27 @@ describe('StringValidator', () => {
 				expect(emailPredicate.parse(input)).toBe(input);
 			});
 
-			test.each(['hi@hello', 'foo@bar', 'foo@bar.com/', 'foo@bar.com/index?search=ok'])('GIVEN %p THEN throws a ConstraintError', (input) => {
+			test.each([
+				'hi@hello',
+				'foo@bar',
+				'foo@bar.com/',
+				'foo@bar.com/index?search=ok',
+				'foo@[object Object].com',
+				'',
+				'without-at-sign',
+				'with@multiple-@-signs',
+				"skywalker@did-you-ever-hear-the-tragedy-of-Darth-Plagueis-The-Wise?-I-thought-not.-It's-not-a-story-the-Jedi-would-tell-you.-It's-a-Sith-legend.-Darth-Plagueis-was-a-Dark-Lord-of-the-Sith,-so-powerful-and-so-wise-he-could-use-the-Force-to-influence-the-midichlorians-to-create-life…-He-had-such-a-knowledge-of-the-dark-side-that-he-could-even-keep-the-ones-he-cared-about-from-dying.-The-dark-side-of-the-Force-is-a-pathway-to-many-abilities-some-consider-to-be-unnatural.-He-became-so-powerful…-the-only-thing-he-was-afraid-of-was-losing-his-power,-which-eventually,-of-course,-he-did.-Unfortunately,-he-taught-his-apprentice-everything-he-knew,-then-his-apprentice-killed-him-in-his-sleep.-Ironic.-He-could-save-others-from-death,-but-not-himself.com",
+				'When-you-look-at-the-dark-side,-careful-you-must-be.-For-the-dark-side-looks-back@master-yoda-swamp.com',
+				'short-account-name@domain-name-that-has-more-than-sixty-three-characters-and-is-then.followed-by-another-segment-that-got-split-by-a-full-stop-symbol.com'
+			])('GIVEN %p THEN throws a ConstraintError', (input) => {
 				expectError(
 					() => emailPredicate.parse(input),
 					new ExpectedConstraintError('s.string.email', 'Invalid email address', input, 'expected to be an email address')
 				);
+			});
+
+			test.each([undefined, null])('GIVEN %p THEN throws a ValidationError', (input) => {
+				expectError(() => emailPredicate.parse(input), new ValidationError('s.string', 'Expected a string primitive', input));
 			});
 		});
 

--- a/tests/validators/string.test.ts
+++ b/tests/validators/string.test.ts
@@ -123,7 +123,8 @@ describe('StringValidator', () => {
 				'with@multiple-@-signs',
 				"skywalker@did-you-ever-hear-the-tragedy-of-Darth-Plagueis-The-Wise?-I-thought-not.-It's-not-a-story-the-Jedi-would-tell-you.-It's-a-Sith-legend.-Darth-Plagueis-was-a-Dark-Lord-of-the-Sith,-so-powerful-and-so-wise-he-could-use-the-Force-to-influence-the-midichlorians-to-create-life…-He-had-such-a-knowledge-of-the-dark-side-that-he-could-even-keep-the-ones-he-cared-about-from-dying.-The-dark-side-of-the-Force-is-a-pathway-to-many-abilities-some-consider-to-be-unnatural.-He-became-so-powerful…-the-only-thing-he-was-afraid-of-was-losing-his-power,-which-eventually,-of-course,-he-did.-Unfortunately,-he-taught-his-apprentice-everything-he-knew,-then-his-apprentice-killed-him-in-his-sleep.-Ironic.-He-could-save-others-from-death,-but-not-himself.com",
 				'When-you-look-at-the-dark-side,-careful-you-must-be.-For-the-dark-side-looks-back@master-yoda-swamp.com',
-				'short-account-name@domain-name-that-has-more-than-sixty-three-characters-and-is-then.followed-by-another-segment-that-got-split-by-a-full-stop-symbol.com'
+				'short-account-name@domain-name-that-has-more-than-sixty-three-characters-and-is-then.followed-by-another-segment-that-got-split-by-a-full-stop-symbol.com',
+				`foo@bar.${'a'.repeat(64)}`
 			])('GIVEN %p THEN throws a ConstraintError', (input) => {
 				expectError(
 					() => emailPredicate.parse(input),

--- a/tests/validators/string.test.ts
+++ b/tests/validators/string.test.ts
@@ -8,8 +8,8 @@ describe('StringValidator', () => {
 		expect(predicate.parse('Hello There')).toBe('Hello There');
 	});
 
-	test('GIVEN a non-string THEN throws ValidationError', () => {
-		expectError(() => predicate.parse(42), new ValidationError('s.string', 'Expected a string primitive', 42));
+	test.each([undefined, null, 42])('GIVEN %p THEN throws a ValidationError', (input) => {
+		expectError(() => predicate.parse(input), new ValidationError('s.string', 'Expected a string primitive', input));
 	});
 
 	describe('Comparators', () => {
@@ -130,10 +130,6 @@ describe('StringValidator', () => {
 					() => emailPredicate.parse(input),
 					new ExpectedConstraintError('s.string.email', 'Invalid email address', input, 'expected to be an email address')
 				);
-			});
-
-			test.each([undefined, null])('GIVEN %p THEN throws a ValidationError', (input) => {
-				expectError(() => emailPredicate.parse(input), new ValidationError('s.string', 'Expected a string primitive', input));
 			});
 		});
 


### PR DESCRIPTION
TODO:
- [x] The statement `if (email.length - lastDotIndex > 63) return false;` is currently uncovered and I also have no idea what input to give to cover it. Please advice.
- [x] Giving `short-account-name@domain-name.-that-has-more-than-sixty-three-characters.com` as input throws a `ReferenceError`, unknown why. This should be solved.