### PR TITLE
fix: make keys optional in object parsing

### DIFF
--- a/src/lib/util-types.ts
+++ b/src/lib/util-types.ts
@@ -7,7 +7,7 @@ export type Type<V> = V extends BaseValidator<infer T> ? T : never;
 type PickDefined<T> = { [K in keyof T as undefined extends T[K] ? never : K]: T[K] };
 
 type PickUndefinedMakeOptional<T> = {
-	[K in keyof T as undefined extends T[K] ? K : never]?: Exclude<T[K], undefined>;
+	[K in keyof T as undefined extends T[K] ? K : never]+?: Exclude<T[K], undefined>;
 };
 
 export type UndefinedToOptional<T> = PickDefined<T> & PickUndefinedMakeOptional<T>;

--- a/src/lib/util-types.ts
+++ b/src/lib/util-types.ts
@@ -4,6 +4,14 @@ export type Constructor<T> = (new (...args: readonly any[]) => T) | (abstract ne
 
 export type Type<V> = V extends BaseValidator<infer T> ? T : never;
 
+type PickDefined<T> = { [K in keyof T as undefined extends T[K] ? never : K]: T[K] };
+
+type PickUndefinedMakeOptional<T> = {
+	[K in keyof T as undefined extends T[K] ? K : never]?: Exclude<T[K], undefined>;
+};
+
+export type UndefinedToOptional<T> = PickDefined<T> & PickUndefinedMakeOptional<T>;
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NonNullObject = {} & object;
 


### PR DESCRIPTION
This pr makes keys optional instead of `| undefined`.
This is a hacky solution, I've tried various ways for 1 hr but can't find a better way of doing it, so if anyone has a better solution then lmk.

[Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAkgdmArsKBeKBvAUASwCYBcUAzsAE45wDmA3FosRGXAIYC2ERpF1UAPlERw8EAGaUIeOgF8sWUJCgAFHAGMA1gBExEvAB4AKgD40WKOcxQA2gGkolKOoggA9qKgGoLYoOE64klAQAB7AEMI+BrYAulAA-FABAG5MUER20URRNrGycgrQKhoAqn7iAXgAsixOAPJgwDgurAA2hiaoZhYY1nYOTq7unt6+IuWBIWERHjHmCXZEyanRcUQAosGqLYgihjEANKP+kiZ58uDQpWO6Bi71jc0sbcZoympax-ovAGRvJWW6ap1BpNVrtKByERbFhkaCqZqkKDBAhXT63e6gp56eBIYBGOTBAB0+C6AHpSQA9OJYIkMJisDhkynUoA)