### PR TITLE
build: use tsup `dts` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"update": "yarn upgrade-interactive",
-		"build": "tsup && tsc -b src",
+		"build": "tsup",
 		"clean": "node scripts/clean.mjs",
 		"typecheck": "tsc -p tsconfig.typecheck.json",
 		"bump": "cliff-jumper",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,9 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../dist",
-		"composite": true,
-		"tsBuildInfoFile": "../dist/.tsbuildinfo",
-		"emitDeclarationOnly": true
+		"incremental": false
 	},
 	"include": ["."]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../tsconfig.base.json",
 	"include": ["."],
-	"references": [{ "path": "../src" }],
 	"compilerOptions": {
 		"types": ["vitest/globals"]
 	}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
 	clean: true,
-	dts: false,
+	dts: true,
 	entry: ['src/index.ts'],
 	format: ['esm', 'cjs', 'iife'],
 	minify: false,


### PR DESCRIPTION
Seeing as our tests do not need composite builds we can disable that in src and then enable `dts` in tsup to make the build process quicker and easier
