### PR TITLE
fix: fixed `s.array` type inference

### DIFF
--- a/src/lib/Shapes.ts
+++ b/src/lib/Shapes.ts
@@ -95,6 +95,8 @@ export class Shapes {
 		return new UnionValidator(validators);
 	}
 
+	public array<T>(validator: BaseValidator<T[][number]>): ArrayValidator<T[], T[][number]>;
+	public array<T extends unknown[]>(validator: BaseValidator<T[number]>): ArrayValidator<T, T[number]>;
 	public array<T extends unknown[]>(validator: BaseValidator<T[number]>) {
 		return new ArrayValidator(validator);
 	}


### PR DESCRIPTION
After this change the following 3 will all resolve their types properly:

![16-59-52_10-07-2022_Code](https://user-images.githubusercontent.com/4019718/178150365-4bb300c1-1ebf-497b-8d8e-450340f789b0.png)
![17-00-08_10-07-2022_Code](https://user-images.githubusercontent.com/4019718/178150367-91343988-3c47-4983-bb8d-fde17749731c.png)
![17-00-37_10-07-2022_Code](https://user-images.githubusercontent.com/4019718/178150368-98cf4d47-f42c-4b6f-9526-1bb8b6cb0259.png)

