### PR TITLE
build: fix djs/builder type error

### DIFF
--- a/src/validators/ArrayValidator.ts
+++ b/src/validators/ArrayValidator.ts
@@ -20,6 +20,7 @@ import { BaseValidator } from './imports';
 
 type makeArray<T> = T extends any[] ? T : T[];
 
+// TODO(v4): revert https://github.com/sapphiredev/shapeshift/pull/159
 export class ArrayValidator<T, I = makeArray<T>[number], P extends unknown[] = makeArray<T>> extends BaseValidator<P> {
 	private readonly validator: BaseValidator<I>;
 

--- a/src/validators/ArrayValidator.ts
+++ b/src/validators/ArrayValidator.ts
@@ -18,78 +18,80 @@ import { Result } from '../lib/Result';
 import type { ExpandSmallerTuples, Tuple, UnshiftTuple } from '../lib/util-types';
 import { BaseValidator } from './imports';
 
-export class ArrayValidator<T extends unknown[], I = T[number]> extends BaseValidator<T> {
+type makeArray<T> = T extends any[] ? T : T[];
+
+export class ArrayValidator<T, I = makeArray<T>[number], P extends unknown[] = makeArray<T>> extends BaseValidator<P> {
 	private readonly validator: BaseValidator<I>;
 
-	public constructor(validator: BaseValidator<I>, constraints: readonly IConstraint<T>[] = []) {
+	public constructor(validator: BaseValidator<I>, constraints: readonly IConstraint<P>[] = []) {
 		super(constraints);
 		this.validator = validator;
 	}
 
 	public lengthLessThan<N extends number>(length: N): ArrayValidator<ExpandSmallerTuples<UnshiftTuple<[...Tuple<I, N>]>>> {
-		return this.addConstraint(arrayLengthLessThan(length) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthLessThan(length) as IConstraint<P>) as any;
 	}
 
 	public lengthLessThanOrEqual<N extends number>(length: N): ArrayValidator<ExpandSmallerTuples<[...Tuple<I, N>]>> {
-		return this.addConstraint(arrayLengthLessThanOrEqual(length) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthLessThanOrEqual(length) as IConstraint<P>) as any;
 	}
 
-	public lengthGreaterThan<N extends number>(length: N): ArrayValidator<[...Tuple<I, N>, I, ...T]> {
-		return this.addConstraint(arrayLengthGreaterThan(length) as IConstraint<T>) as any;
+	public lengthGreaterThan<N extends number>(length: N): ArrayValidator<[...Tuple<I, N>, I, ...P]> {
+		return this.addConstraint(arrayLengthGreaterThan(length) as IConstraint<P>) as any;
 	}
 
-	public lengthGreaterThanOrEqual<N extends number>(length: N): ArrayValidator<[...Tuple<I, N>, ...T]> {
-		return this.addConstraint(arrayLengthGreaterThanOrEqual(length) as IConstraint<T>) as any;
+	public lengthGreaterThanOrEqual<N extends number>(length: N): ArrayValidator<[...Tuple<I, N>, ...P]> {
+		return this.addConstraint(arrayLengthGreaterThanOrEqual(length) as IConstraint<P>) as any;
 	}
 
 	public lengthEqual<N extends number>(length: N): ArrayValidator<[...Tuple<I, N>]> {
-		return this.addConstraint(arrayLengthEqual(length) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthEqual(length) as IConstraint<P>) as any;
 	}
 
-	public lengthNotEqual(length: number): ArrayValidator<[...T]> {
-		return this.addConstraint(arrayLengthNotEqual(length) as IConstraint<T>) as any;
+	public lengthNotEqual(length: number): ArrayValidator<[...P]> {
+		return this.addConstraint(arrayLengthNotEqual(length) as IConstraint<P>) as any;
 	}
 
 	public lengthRange<S extends number, E extends number>(
 		start: S,
 		endBefore: E
 	): ArrayValidator<Exclude<ExpandSmallerTuples<UnshiftTuple<[...Tuple<I, E>]>>, ExpandSmallerTuples<UnshiftTuple<[...Tuple<I, S>]>>>> {
-		return this.addConstraint(arrayLengthRange(start, endBefore) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthRange(start, endBefore) as IConstraint<P>) as any;
 	}
 
 	public lengthRangeInclusive<S extends number, E extends number>(
 		startAt: S,
 		endAt: E
 	): ArrayValidator<Exclude<ExpandSmallerTuples<[...Tuple<I, E>]>, ExpandSmallerTuples<UnshiftTuple<[...Tuple<I, S>]>>>> {
-		return this.addConstraint(arrayLengthRangeInclusive(startAt, endAt) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthRangeInclusive(startAt, endAt) as IConstraint<P>) as any;
 	}
 
 	public lengthRangeExclusive<S extends number, E extends number>(
 		startAfter: S,
 		endBefore: E
 	): ArrayValidator<Exclude<ExpandSmallerTuples<UnshiftTuple<[...Tuple<I, E>]>>, ExpandSmallerTuples<[...Tuple<T, S>]>>> {
-		return this.addConstraint(arrayLengthRangeExclusive(startAfter, endBefore) as IConstraint<T>) as any;
+		return this.addConstraint(arrayLengthRangeExclusive(startAfter, endBefore) as IConstraint<P>) as any;
 	}
 
 	public get unique(): this {
-		return this.addConstraint(uniqueArray as IConstraint<T>);
+		return this.addConstraint(uniqueArray as IConstraint<P>);
 	}
 
 	protected override clone(): this {
 		return Reflect.construct(this.constructor, [this.validator, this.constraints]);
 	}
 
-	protected handle(values: unknown): Result<T, ValidationError | CombinedPropertyError> {
+	protected handle(values: unknown): Result<P, ValidationError | CombinedPropertyError> {
 		if (!Array.isArray(values)) {
 			return Result.err(new ValidationError('s.array(T)', 'Expected an array', values));
 		}
 
 		if (!this.shouldRunConstraints) {
-			return Result.ok(values as T);
+			return Result.ok(values as P);
 		}
 
 		const errors: [number, BaseError][] = [];
-		const transformed: T = [] as unknown as T;
+		const transformed: P = [] as unknown as P;
 
 		for (let i = 0; i < values.length; i++) {
 			const result = this.validator.run(values[i]);


### PR DESCRIPTION
similar to https://github.com/sapphiredev/shapeshift/pull/153
this pr tried to fix the djs/builder error.
djs/builder was compiled with an older version of `shapeshift` when `ArrayValidator` was accepting any type as the first generic type. But after https://github.com/sapphiredev/shapeshift/pull/140, it expects  `unknown[]` type. That's why users are getting type errors. 

> **Note**
`type makeArray<T> = T extends any[] ? T : T[];` can be removed by making `P` 2nd generic type instead of 3rd. But then it'll throw the same error for packages that were compiled with a new version of `shapeshift` which's 2nd param is not an array type.
So in the future, when we'll release v4, we can remove it