### PR TITLE
fix: fixed "jump to definition" for `undefinedToOptional` going to wrong symbol

### DIFF
--- a/src/lib/util-types.ts
+++ b/src/lib/util-types.ts
@@ -9,13 +9,28 @@ export type Type<V> = V extends BaseValidator<infer T> ? T : never;
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NonNullObject = {} & object;
 
+/**
+ * @deprecated This type is no longer used and will be removed in the next major version.
+ */
 export type PickDefined<T> = { [K in keyof T as undefined extends T[K] ? never : K]: T[K] };
 
+/**
+ * @deprecated This type is no longer used and will be removed in the next major version.
+ */
 export type PickUndefinedMakeOptional<T> = {
 	[K in keyof T as undefined extends T[K] ? K : never]+?: Exclude<T[K], undefined>;
 };
 
-export type UndefinedToOptional<T> = PickDefined<T> & PickUndefinedMakeOptional<T>;
+type FilterDefinedKeys<TObj extends NonNullObject> = Exclude<
+	{
+		[TKey in keyof TObj]: undefined extends TObj[TKey] ? never : TKey;
+	}[keyof TObj],
+	undefined
+>;
+
+export type UndefinedToOptional<T extends NonNullObject> = Pick<T, FilterDefinedKeys<T>> & {
+	[k in keyof Omit<T, FilterDefinedKeys<T>>]?: Exclude<T[k], undefined>;
+};
 
 export type MappedObjectValidator<T> = { [key in keyof T]: BaseValidator<T[key]> };
 


### PR DESCRIPTION
I broke jump to definition of `ObjectValidator` when adding `undefinedToOptional`

ref: https://github.com/microsoft/TypeScript/issues/47813
there's a pr to fix it too: https://github.com/microsoft/TypeScript/pull/51650