### PR TITLE
fix: resolve minor grammar mistake

### DIFF
--- a/src/constraints/StringConstraints.ts
+++ b/src/constraints/StringConstraints.ts
@@ -102,7 +102,7 @@ export function stringUrl(options?: UrlOptions): IConstraint<string> {
 			try {
 				url = new URL(input);
 			} catch {
-				return Result.err(new ExpectedConstraintError('s.string.url', 'Invalid URL', input, 'expected to match an URL'));
+				return Result.err(new ExpectedConstraintError('s.string.url', 'Invalid URL', input, 'expected to match a URL'));
 			}
 
 			const validatorFnResult = validatorFn(input, url);

--- a/tests/validators/string.test.ts
+++ b/tests/validators/string.test.ts
@@ -144,7 +144,7 @@ describe('StringValidator', () => {
 				test.each(['google.com', 'foo.bar'])('GIVEN %j THEN throws a ConstraintError', (input) => {
 					expectError(
 						() => urlPredicate.parse(input),
-						new ExpectedConstraintError('s.string.url', 'Invalid URL', input, 'expected to match an URL')
+						new ExpectedConstraintError('s.string.url', 'Invalid URL', input, 'expected to match a URL')
 					);
 				});
 			});


### PR DESCRIPTION
Even though the U in URL is a vowel, the U is pronounced “you.”. Since the letter Y is a consonant in this case, "a" needs to be used here instead of "an".